### PR TITLE
add missing return statement for wald distribution

### DIFF
--- a/src/chaospy/dist/collection.py
+++ b/src/chaospy/dist/collection.py
@@ -989,6 +989,7 @@ def Wald(mu=0, scale=1, shift=0):
     """
     dist = co.wald(mu)*scale + shift
     dist.addattr(str="Wald(%s,%s,%s)"%(mu, scale, shift))
+    return dist
 
 
 def Weibull(shape=1, scale=1, shift=0):


### PR DESCRIPTION
I am just getting to know chaospy, but this looks like a typo to me. Shouldn't ```dist.collection.Wald``` return a ```dist.backend.Dist``` object?