### PR TITLE
Fixed Python 3 TypeError

### DIFF
--- a/src/chaospy/quad/collection/leja.py
+++ b/src/chaospy/quad/collection/leja.py
@@ -38,7 +38,7 @@ def quad_leja(order, dist):
 
     lower, upper = dist.range()
     abscissas = [lower, dist.mom(1), upper]
-    for _ in range(order):
+    for _ in range(int(order)):
 
         obj = create_objective(dist, abscissas)
         opts, vals = zip(


### PR DESCRIPTION
The following code gave errors only in Python 3:

    import chaospy as cp

    distribution = cp.Uniform(0.75, 1.75)
    quadrature_order = 5
    cp.generate_quadrature(quadrature_order, distribution, rule="J", sparse=True)

    Traceback (most recent call last):
      File "chaospy_python3.py", line 16, in <module>
        cp.generate_quadrature(quadrature_order, distribution, rule="J", sparse=True)
      File "/home/simen/phd/projects/chaospy/src/chaospy/quad/interface.py", line 64, in     generate_quadrature
        abscissas, weights = sparse_grid.sparse_grid(quad_function, order, dim)
      File "/home/simen/phd/projects/chaospy/src/chaospy/quad/sparse_grid.py", line 31, in sparse_grid
        return sparse_grid(func, m_order, dim, skew)
      File "/home/simen/phd/projects/chaospy/src/chaospy/quad/sparse_grid.py", line 47, in sparse_grid
        abscissa, weight = func(skew+idb)
      File "/home/simen/phd/projects/chaospy/src/chaospy/quad/collection/frontend.py", line 84, in _quad_function
        return quad_function(order, *args, **params)
      File "/home/simen/phd/projects/chaospy/src/chaospy/quad/collection/leja.py", line 41, in quad_leja
        for _ in range(order):
    TypeError: only integer scalar arrays can be converted to a scalar index


The reason is that the following only works with Python 2, and not with Python 3:

    import numpy as np

    order = np.array([5])
    for i in range(order):
        print(i)

Converting `order` to `int()` solves the problem. There are other occurrences of `range(order...` that might lead to errors, but I am not certain of this.