### PR TITLE
Added 1D OpenTURNS distributions wrapper

### DIFF
--- a/src/chaospy/distributions/collection.py
+++ b/src/chaospy/distributions/collection.py
@@ -737,6 +737,17 @@ def Normal(mu=0, sigma=1):
     return dist
 
 
+def OTDistribution(distribution):
+    """
+    OpenTURNS distribution.
+
+    Args:
+        distribution (openturns.Distribution, Dist) : underlying OT distribution
+    """
+    dist = cores.otdistribution(distribution)
+    return dist
+
+
 def Pareto1(shape=1, scale=1, loc=0):
     """
     Pareto type 1 distribution.

--- a/src/chaospy/distributions/cores.py
+++ b/src/chaospy/distributions/cores.py
@@ -14,6 +14,25 @@ from scipy import special
 from .baseclass import Dist
 from . import joint
 
+class otdistribution(Dist):
+    def __init__(self, distribution):
+        Dist.__init__(self)
+        if distribution.getDimension() != 1:
+            raise Exception("Only 1D OpenTURNS distribution are supported for now")
+        self.distribution = distribution
+    def _pdf(self, x):
+        return np.array(self.distribution.computePDF(np.atleast_2d(x).T).asPoint())
+    def _cdf(self, x):
+        return np.array(self.distribution.computeCDF(np.atleast_2d(x).T).asPoint())
+    def _ppf(self, q):
+        return np.array(self.distribution.computeQuantile(q[0]).asPoint())
+    def _bnd(self):
+        rng = self.distribution.getRange()
+        return rng.getLowerBound()[0], rng.getUpperBound()[0]
+    def _mom(self, k):
+        return self.getMoment(k)[0]
+    def _str(self):
+        return self.distribution.__str__()
 
 
 class uniform(Dist):


### PR DESCRIPTION
This is a first attempt to wrap OpenTURNS 1D distributions into chaospy distributions. I have no idea yet on how to wrap the multivariate distributions (eg Dirichlet or Multinomial), any advice is welcomed!

With this script:
```
import openturns as ot
import chaospy as cp
import numpy as np

x = [2.3, -0.8]
x_ot = np.atleast_2d(x).T
q = [0.1, 0.23]

mu = 1.0
sigma = 2.0
d_ot = ot.Normal(mu, sigma)
d_otcp = cp.OTDistribution(d_ot)
d_cp = cp.Normal(mu=mu, sigma=sigma)

# Here we adapt OpenTURNS output for presentation purpose
print("PDF")
print("OT  :", np.array(d_ot.computePDF(x_ot).asPoint()))
print("CP  :", d_cp.pdf(x))
print("OTCP:", d_otcp.pdf(x))
print("CDF")
print("OT  :", np.array(d_ot.computeCDF(x_ot).asPoint()))
print("CP  :", d_cp.cdf(x))
print("OTCP:", d_otcp.cdf(x))
print("INV")
print("CP  :", d_cp.inv(q))
print("OT  :", np.array(d_ot.computeQuantile(q).asPoint()))
print("OTCP:", d_otcp.inv(q))
```
you should get:
```
PDF
OT  : [0.16148618 0.13304262]
CP  : [0.16148618 0.13304262]
OTCP: [0.16148618 0.13304262]
CDF
OT  : [0.74215389 0.18406013]
CP  : [0.74215389 0.18406013]
OTCP: [0.74215389 0.18406013]
INV
CP  : [-1.56310313 -0.4776937 ]
OT  : [-1.56310313 -0.4776937 ]
OTCP: [-1.56310313 -0.4776937 ]
```