### PR TITLE
Making normalization optional

### DIFF
--- a/chaospy/distributions/approximation.py
+++ b/chaospy/distributions/approximation.py
@@ -292,7 +292,7 @@ def approximate_moment(
     if dim > 1:
         shape = shape[1:]
 
-    X, W = quad.generate_quadrature(order, dist, rule=rule, **kws)
+    X, W = quad.generate_quadrature(order, dist, rule=rule, normalize=True, **kws)
 
     grid = numpy.mgrid[:len(X[0]), :size]
     X = X.T[grid[0]].T

--- a/chaospy/quad/collection/fejer.py
+++ b/chaospy/quad/collection/fejer.py
@@ -12,7 +12,8 @@ The first few orders with linear growth rule::
 
     >>> distribution = chaospy.Uniform(0, 1)
     >>> for order in [0, 1, 2, 3]:
-    ...     X, W = chaospy.generate_quadrature(order, distribution, rule="F")
+    ...     X, W = chaospy.generate_quadrature(
+    ...         order, distribution, normalize=True, rule="F")
     ...     print("{} {} {}".format(order, numpy.around(X, 3), numpy.around(W, 3)))
     0 [[0.5]] [1.]
     1 [[0.25 0.75]] [0.5 0.5]
@@ -23,7 +24,7 @@ The first few orders with exponential growth rule::
 
     >>> for order in [0, 1, 2]:
     ...     X, W = chaospy.generate_quadrature(
-    ...         order, distribution, rule="F", growth=True)
+    ...         order, distribution, normalize=True, rule="F", growth=True)
     ...     print("{} {} {}".format(order, numpy.around(X, 2), numpy.around(W, 2)))
     0 [[0.5]] [1.]
     1 [[0.15 0.5  0.85]] [0.29 0.43 0.29]

--- a/chaospy/quad/collection/frontend.py
+++ b/chaospy/quad/collection/frontend.py
@@ -89,14 +89,12 @@ def get_function(rule, domain, normalize, **parameters):
         abscissas, weights = quad_function(order, *args, **params)
 
         # normalize if prudent:
-        if (
-                rule in UNORMALIZED_QUADRATURE_RULES and
-                normalize and isinstance(domain, Dist)
-        ):
-            if len(domain) == 1:
-                weights *= domain.pdf(abscissas).flatten()
-            else:
-                weights *= domain.pdf(abscissas)
+        if rule in UNORMALIZED_QUADRATURE_RULES and normalize:
+            if isinstance(domain, Dist):
+                if len(domain) == 1:
+                    weights *= domain.pdf(abscissas).flatten()
+                else:
+                    weights *= domain.pdf(abscissas)
             weights /= numpy.sum(weights)
 
         return abscissas, weights

--- a/chaospy/quad/collection/frontend.py
+++ b/chaospy/quad/collection/frontend.py
@@ -30,9 +30,17 @@ QUAD_SHORT_NAMES = {
     "f": "fejer",
 }
 
+UNORMALIZED_QUADRATURE_RULES = (
+    "clenshaw_curtis",
+    "gauss_legendre",
+    "gauss_patterson",
+    "genz_keister",
+    "fejer",
+)
 
 
-def get_function(rule, domain, **parameters):
+
+def get_function(rule, domain, normalize, **parameters):
     """
     Create a quadrature function and set default parameter values.
 
@@ -43,6 +51,12 @@ def get_function(rule, domain, **parameters):
             Defines ``lower`` and ``upper`` that is passed quadrature rule. If
             ``Dist``, ``domain`` is renamed to ``dist`` and also
             passed.
+        normalize (bool):
+            In the case of distributions, the abscissas and weights are not
+            tailored to a distribution beyond matching the bounds. If True, the
+            samples are normalized multiplying the weights with the density of
+            the distribution evaluated at the abscissas and normalized
+            afterwards to sum to one.
         parameters (:py:data:typing.Any):
             Redefining of the parameter defaults. Only add parameters that the
             quadrature rule expect.
@@ -72,6 +86,19 @@ def get_function(rule, domain, **parameters):
         """Implementation of quadrature function."""
         params = parameters_spec.copy()
         params.update(kws)
-        return quad_function(order, *args, **params)
+        abscissas, weights = quad_function(order, *args, **params)
+
+        # normalize if prudent:
+        if (
+                rule in UNORMALIZED_QUADRATURE_RULES and
+                normalize and isinstance(domain, Dist)
+        ):
+            if len(domain) == 1:
+                weights *= domain.pdf(abscissas).flatten()
+            else:
+                weights *= domain.pdf(abscissas)
+            weights /= numpy.sum(weights)
+
+        return abscissas, weights
 
     return _quad_function

--- a/chaospy/quad/collection/gauss_legendre.py
+++ b/chaospy/quad/collection/gauss_legendre.py
@@ -18,7 +18,7 @@ The first few orders::
     >>> distribution = chaospy.Uniform(0, 1)
     >>> for order in [0, 1, 2, 3]:
     ...     abscissas, weights = chaospy.generate_quadrature(
-    ...         order, distribution, rule="E")
+    ...         order, distribution, rule="E", normalize=True)
     ...     print("{} {} {}".format(order, numpy.around(abscissas, 3), numpy.around(weights, 3)))
     0 [[0.5]] [1.]
     1 [[0.211 0.789]] [0.5 0.5]
@@ -30,7 +30,7 @@ Using an alternative distribution::
     >>> distribution = chaospy.Beta(2, 4)
     >>> for order in [0, 1, 2, 3]:
     ...     abscissas, weights = chaospy.generate_quadrature(
-    ...         order, distribution, rule="E")
+    ...         order, distribution, rule="E", normalize=True)
     ...     print("{} {} {}".format(order, numpy.around(abscissas, 3), numpy.around(weights, 3)))
     0 [[0.5]] [1.]
     1 [[0.211 0.789]] [0.933 0.067]

--- a/chaospy/quad/interface.py
+++ b/chaospy/quad/interface.py
@@ -7,8 +7,10 @@ from scipy.misc import comb
 from . import collection, sparse_grid
 
 
-def generate_quadrature(order, domain, accuracy=100, sparse=False, rule="C",
-                        composite=1, growth=None, part=None, **kws):
+def generate_quadrature(
+        order, domain, accuracy=100, sparse=False, rule="C",
+        composite=1, growth=None, part=None, normalize=False, **kws,
+):
     """
     Numerical quadrature node and weight generator.
 
@@ -34,6 +36,12 @@ def generate_quadrature(order, domain, accuracy=100, sparse=False, rule="C",
             If provided, composite quadrature will be used.  Value determines
             the number of domains along an axis. Ignored in the case
             gaussian=True.
+        normalize (bool):
+            In the case of distributions, the abscissas and weights are not
+            tailored to a distribution beyond matching the bounds. If True, the
+            samples are normalized multiplying the weights with the density of
+            the distribution evaluated at the abscissas and normalized
+            afterwards to sum to one.
         growth (bool):
             If True sets the growth rule for the composite quadrature rule to
             exponential for Clenshaw-Curtis quadrature.
@@ -52,6 +60,7 @@ def generate_quadrature(order, domain, accuracy=100, sparse=False, rule="C",
     quad_function = collection.get_function(
         rule,
         domain,
+        normalize,
         growth=growth,
         composite=composite,
         accuracy=accuracy,

--- a/chaospy/quad/interface.py
+++ b/chaospy/quad/interface.py
@@ -67,13 +67,4 @@ def generate_quadrature(order, domain, accuracy=100, sparse=False, rule="C",
     assert len(weights) == abscissas.shape[1]
     assert len(abscissas.shape) == 2
 
-    if isdist:
-        if rule != "golub_welsch":
-            if dim == 1:
-                weights *= domain.pdf(abscissas).flatten()
-            else:
-                weights *= domain.pdf(abscissas)
-        if not sparse:
-            weights /= np.sum(weights)
-
     return abscissas, weights

--- a/chaospy/quad/interface.py
+++ b/chaospy/quad/interface.py
@@ -9,7 +9,7 @@ from . import collection, sparse_grid
 
 def generate_quadrature(
         order, domain, accuracy=100, sparse=False, rule="C",
-        composite=1, growth=None, part=None, normalize=False, **kws,
+        composite=1, growth=None, part=None, normalize=False, **kws
 ):
     """
     Numerical quadrature node and weight generator.

--- a/chaospy/quad/sparse_grid.py
+++ b/chaospy/quad/sparse_grid.py
@@ -11,7 +11,7 @@ To use Smolyak sparse-grid in ``chaospy``, just pass the flag ``sparse=True``
 to the ``generate_quadrature`` function. For example::
 
     >>> distribution = chaospy.J(chaospy.Uniform(0, 4), chaospy.Uniform(0, 4))
-    >>> X, W = chaospy.generate_quadrature(3, distribution, sparse=True)
+    >>> X, W = chaospy.generate_quadrature(3, distribution, normalize=True, sparse=True)
     >>> print(numpy.around(X, 4))
     [[0. 2. 4. 2. 0. 1. 2. 3. 4. 2. 0. 2. 4.]
      [0. 0. 0. 1. 2. 2. 2. 2. 2. 3. 4. 4. 4.]]
@@ -21,7 +21,7 @@ to the ``generate_quadrature`` function. For example::
 
 This compared to the full tensor-product grid::
 
-    >>> X, W = chaospy.generate_quadrature(3, distribution)
+    >>> X, W = chaospy.generate_quadrature(3, distribution, normalize=True)
     >>> print(numpy.around(X, 4))
     [[0. 0. 0. 0. 1. 1. 1. 1. 3. 3. 3. 3. 4. 4. 4. 4.]
      [0. 1. 3. 4. 0. 1. 3. 4. 0. 1. 3. 4. 0. 1. 3. 4.]]


### PR DESCRIPTION
Some of the quadrature rules are not fit for purpose for doing numerical integration, in that they are tailored to an interval instead of a distribution. In other words, they are only designed for the Uniform distribution.
To fix this, the quadrature weights are multiplied by the probability density function evaluated at the abscissas and normalized to sum to 1. Okay for moment estimation, but there are use-cases where raw abscissas-weights is needed.

So in the transition from v2 to v3, the normalization was turned on by default, causing havoc in the user cases where this isn't wanted in user space. To fix this, a new flag `normalize` is added to allow to turn the features on-and-off. It will be on for moment-approximation and off for userspace, which is expected behavior.

Some algorithms are already optimal with respect to distributions. These are not normalize non-the-less.