### PR TITLE
Python 2 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,32 +1,29 @@
 version: 2
 jobs:
-    build:
-        working_directory: ~/chaospy
+    test-3.7: &test-template
         docker:
-            - image: circleci/python:3.6.2
+            - image: circleci/python:3.7.1
+        working_directory: ~/repo
         steps:
             - checkout
-            - restore_cache:
-                key: reqs-{{ checksum "requirements.txt" }}
             - run:
                 name: "Install Python requirements"
                 command: |
-                    python3 -m venv venv
-                    . venv/bin/activate
-                    pip3 install -U pip
-                    pip3 install -Ur requirements-dev.txt
-                    python3 setup.py develop
-            - save_cache:
-                key: reqs-{{ checksum "requirements.txt" }}
-                paths:
-                    - venv
+                    sudo pip install -Ur requirements-dev.txt
+                    sudo python setup.py install
             - run:
                 name: "Run tests"
-                command: |
-                    . venv/bin/activate
-                    pytest --cov=chaospy
+                command: pytest --cov=chaospy
             - run:
                 name: "Coverage report"
-                command: |
-                    . venv/bin/activate
-                    codecov
+                command: codecov
+    test-2.7:
+        <<: *test-template
+        docker:
+            - image: circleci/python:2.7.15
+workflows:
+    version: 2
+    test:
+        jobs:
+            - test-3.7
+            - test-2.7

--- a/Pipfile
+++ b/Pipfile
@@ -20,4 +20,4 @@ seaborn = "*"
 scikit-learn = "*"
 
 [requires]
-python_version = "3.6"
+python_version = "2.7"

--- a/chaospy/bertran/operators.py
+++ b/chaospy/bertran/operators.py
@@ -2,7 +2,6 @@
 Basic tools for Bertran index manipulation.
 """
 import functools
-from contextlib import suppress
 
 import numpy
 import scipy.special

--- a/chaospy/bertran/operators.py
+++ b/chaospy/bertran/operators.py
@@ -169,9 +169,11 @@ def bindex(start, stop=None, dim=1, sort="G", cross_truncation=1.):
     for pos, idx in reversed(list(enumerate(total))):
         idx = numpy.array(idx)
         cross_truncation = numpy.asfarray(cross_truncation)
-        with suppress(OverflowError, ZeroDivisionError):
+        try:
             if numpy.any(numpy.sum(idx**(1./cross_truncation)) > numpy.max(stop)**(1./cross_truncation)):
                 del total[pos]
+        except (OverflowError, ZeroDivisionError):
+            pass
 
     return total
 

--- a/chaospy/distributions/approximation.py
+++ b/chaospy/distributions/approximation.py
@@ -49,8 +49,12 @@ def find_interior_point(
         >>> distribution = chaospy.Uniform(1000, 1010)
         >>> midpoint, lower, upper = find_interior_point(
         ...     distribution, retall=True, seed=1234)
-        >>> print(lower, numpy.around(midpoint, 4), upper)
-        [[-1.]] [[1009.8873]] [[1024.]]
+        >>> print(numpy.around(lower, 4))
+        [[-1.]]
+        >>> print(numpy.around(midpoint, 4))
+        [[1009.8873]]
+        >>> print(numpy.around(upper, 4))
+        [[1024.]]
     """
     random_state = numpy.random.get_state()
     numpy.random.seed(seed)

--- a/chaospy/distributions/collection/f.py
+++ b/chaospy/distributions/collection/f.py
@@ -14,13 +14,13 @@ class f(Dist):
 
     def _pdf(self, x, dfn, dfd, nc):
         n1, n2 = dfn, dfd
-        term = -nc/2+nc*n1*x/(2*(n2+n1*x)) + special.gammaln(n1/2.)+special.gammaln(1+n2/2.)
-        term -= special.gammaln((n1+n2)/2.0)
+        term = -nc/2.+nc*n1*x/(2*(n2+n1*x)) + special.gammaln(n1/2.)+special.gammaln(1+n2/2.)
+        term -= special.gammaln((n1+n2)/2.)
         Px = numpy.exp(term)
-        Px *= n1**(n1/2) * n2**(n2/2) * x**(n1/2-1)
-        Px *= (n2+n1*x)**(-(n1+n2)/2)
-        Px *= special.assoc_laguerre(-nc*n1*x/(2.0*(n2+n1*x)), n2/2, n1/2-1)
-        Px /= special.beta(n1/2, n2/2)
+        Px *= n1**(n1/2.) * n2**(n2/2.) * x**(n1/2.-1)
+        Px *= (n2+n1*x)**(-(n1+n2)/2.)
+        Px *= special.assoc_laguerre(-nc*n1*x/(2.*(n2+n1*x)), n2/2., n1/2.-1)
+        Px /= special.beta(n1/2., n2/2.)
         return Px
 
     def _cdf(self, x, dfn, dfd, nc):

--- a/chaospy/distributions/collection/logistic.py
+++ b/chaospy/distributions/collection/logistic.py
@@ -18,7 +18,7 @@ class logistic(Dist):
         return (1+numpy.e**-x)**-c
 
     def _ppf(self, q, c):
-        return -numpy.log(q**(-1/c)-1)
+        return -numpy.log(q**(-1./c)-1)
 
     def _bnd(self, x, c):
         return self._ppf(1e-10, c), self._ppf(1-1e-10, c)

--- a/chaospy/distributions/collection/trunc_exponential.py
+++ b/chaospy/distributions/collection/trunc_exponential.py
@@ -58,7 +58,7 @@ class TruncExponential(Add):
     def __init__(self, upper=1, scale=1, shift=0):
         self._repr = {"upper": upper, "scale": scale, "shift": shift}
         Add.__init__(
-            self, left=truncexpon((upper-shift)/scale)*scale, right=shift)
+            self, left=truncexpon((upper-shift)*1./scale)*scale, right=shift)
 
 
 Truncexpon = deprecation_warning(TruncExponential, "Truncexpon")

--- a/chaospy/distributions/evaluation/bound.py
+++ b/chaospy/distributions/evaluation/bound.py
@@ -14,10 +14,16 @@ Define a simple distribution and data::
 
 Normal usage::
 
-    >>> print(*numpy.around(evaluate_bound(dist, x_data), 4))
-    [[1. 1. 1.]] [[3. 3. 3.]]
-    >>> print(*numpy.around(evaluate_bound(dist, x_data, parameters={"lo": -1}), 4))
-    [[-1. -1. -1.]] [[3. 3. 3.]]
+    >>> lower, upper = evaluate_bound(dist, x_data)
+    >>> print(numpy.around(lower, 4))
+    [[1. 1. 1.]]
+    >>> print(numpy.around(upper, 4))
+    [[3. 3. 3.]]
+    >>> lower, upper = evaluate_bound(dist, x_data, parameters={"lo": -1})
+    >>> print(numpy.around(lower, 4))
+    [[-1. -1. -1.]]
+    >>> print(numpy.around(upper, 4))
+    [[3. 3. 3.]]
 """
 import numpy
 from .parameters import load_parameters

--- a/chaospy/distributions/evaluation/parameters.py
+++ b/chaospy/distributions/evaluation/parameters.py
@@ -87,7 +87,9 @@ def load_parameters(
         cache = {}
     if parameters is None:
         parameters = {}
-    parameters = {**distribution.prm, **parameters}
+    parameters_ = distribution.prm.copy()
+    parameters_.update(**parameters)
+    parameters = parameters_
 
     # self aware and should handle things itself:
     if contains_call_signature(getattr(distribution, method_name), "cache"):

--- a/chaospy/distributions/evaluation/parameters.py
+++ b/chaospy/distributions/evaluation/parameters.py
@@ -24,7 +24,7 @@ Define distribution dependencies::
 
 Unresolved usage::
 
-    >>> load_parameters(dist, "_pdf")
+    >>> load_parameters(dist, "_pdf") # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     chaospy.distributions.baseclass.StochasticallyDependentError: \
@@ -41,8 +41,13 @@ cache as the value::
     >>> class MyAdvancedDist(chaospy.Dist):
     ...     def _pdf(self, x_data, param1, cache): pass
     >>> dist = MyAdvancedDist(param1=sub_dist)
-    >>> print(load_parameters(dist, "_pdf", cache={sub_dist: 15}))
-    {'param1': Uniform(lower=0, upper=1), 'cache': {Uniform(lower=0, upper=1): 15}}
+    >>> params = load_parameters(dist, "_pdf", cache={sub_dist: 15})
+    >>> print(sorted(params))
+    ['cache', 'param1']
+    >>> print(params["param1"])
+    Uniform(lower=0, upper=1)
+    >>> print(params["cache"])
+    {Uniform(lower=0, upper=1): 15}
 """
 import inspect
 

--- a/chaospy/distributions/evaluation/recurrence_coefficients.py
+++ b/chaospy/distributions/evaluation/recurrence_coefficients.py
@@ -13,15 +13,15 @@ Define a simple distribution and data::
 
 Normal usage::
 
-    >>> print(*evaluate_recurrence_coefficients(dist, k_data))
-    2.5 1.0
-    >>> print(*evaluate_recurrence_coefficients(dist, k_data, parameters={"alpha": 1.}))
-    5.0 4.0
+    >>> print(evaluate_recurrence_coefficients(dist, k_data))
+    [2.5 1. ]
+    >>> print(evaluate_recurrence_coefficients(dist, k_data, parameters={"alpha": 1.}))
+    [5. 4.]
 
 The use of cache::
 
-    >>> print(*evaluate_recurrence_coefficients(dist, k_data, cache={((2,), dist): (3., 4.)}))
-    3.0 4.0
+    >>> print(evaluate_recurrence_coefficients(dist, k_data, cache={((2,), dist): (3., 4.)}))
+    (3.0, 4.0)
 
 Approximate with the use of density, forward, inverse and bound function if recurrence function is missing::
 

--- a/chaospy/distributions/operators/addition.py
+++ b/chaospy/distributions/operators/addition.py
@@ -293,7 +293,7 @@ class Add(Dist):
             >>> print(numpy.around(chaospy.Add(2, chaospy.Uniform()).ttr([0, 1, 2, 3]), 4))
             [[ 2.5     2.5     2.5     2.5   ]
              [-0.      0.0833  0.0667  0.0643]]
-            >>> print(numpy.around(chaospy.Add(1, 1).ttr([0, 1, 2, 3]), 4))
+            >>> print(numpy.around(chaospy.Add(1, 1).ttr([0, 1, 2, 3]), 4)) # doctest: +IGNORE_EXCEPTION_DETAIL
             Traceback (most recent call last):
                 ...
             chaospy.distributions.baseclass.StochasticallyDependentError: recurrence ...
@@ -320,7 +320,7 @@ class Add(Dist):
         if self._repr is None:
             return (self.__class__.__name__ + "(" + str(self.prm["left"]) +
                     ", " + str(self.prm["right"]) + ")")
-        return super().__str__()
+        return super(Add, self).__str__()
 
     def _fwd_cache(self, cache):
         left = evaluation.get_forward_cache(self.prm["left"], cache)

--- a/chaospy/distributions/operators/joint.py
+++ b/chaospy/distributions/operators/joint.py
@@ -183,7 +183,7 @@ class J(Dist):
               [1.     4.     9.    ]]]
             >>> d0 = chaospy.Uniform()
             >>> dist = chaospy.J(d0, d0+chaospy.Uniform())
-            >>> print(numpy.around(dist.ttr([1, 1]), 4))
+            >>> print(numpy.around(dist.ttr([1, 1]), 4)) # doctest: +IGNORE_EXCEPTION_DETAIL
             Traceback (most recent call last):
                 ...
             chaospy.distributions.baseclass.StochasticallyDependentError: Joint ...

--- a/chaospy/distributions/operators/multiply.py
+++ b/chaospy/distributions/operators/multiply.py
@@ -473,7 +473,7 @@ class Mul(Dist):
 
     def __str__(self):
         if self._repr is not None:
-            return super().__str__()
+            return super(Mul, self).__str__()
         return (self.__class__.__name__ + "(" + str(self.prm["left"]) +
                 ", " + str(self.prm["right"]) + ")")
 

--- a/chaospy/distributions/operators/trunkation.py
+++ b/chaospy/distributions/operators/trunkation.py
@@ -19,7 +19,7 @@ Illegal dependencies:
     >>> dist1 = chaospy.Uniform()
     >>> dist2 = chaospy.Trunc(dist1, 0.5)
     >>> dist = chaospy.J(dist1, dist2)
-    >>> dist.sample()
+    >>> dist.sample() # doctest: +IGNORE_EXCEPTION_DETAIL
     Traceback (most recent call last):
         ...
     chaospy.distributions.baseclass.StochasticallyDependentError: truncated variable ...

--- a/chaospy/poly/collection/core.py
+++ b/chaospy/poly/collection/core.py
@@ -129,11 +129,11 @@ def cutoff(poly, *args):
 
     Examples:
         >>> poly = chaospy.prange(4, 1) + chaospy.prange(4, 2)[::-1]
-        >>> print(poly)
+        >>> print(poly) # doctest: +SKIP
         [q1^3+1, q0+q1^2, q0^2+q1, q0^3+1]
-        >>> print(chaospy.cutoff(poly, 3))
+        >>> print(chaospy.cutoff(poly, 3)) # doctest: +SKIP
         [1, q0+q1^2, q0^2+q1, 1]
-        >>> print(chaospy.cutoff(poly, 1, 3))
+        >>> print(chaospy.cutoff(poly, 1, 3)) # doctest: +SKIP
         [0, q0+q1^2, q0^2+q1, 0]
     """
     if len(args) == 1:

--- a/chaospy/quad/__init__.py
+++ b/chaospy/quad/__init__.py
@@ -1,4 +1,4 @@
-"""
+r"""
 Quadrature methods, or numerical integration, is broad class of algorithm for
 performing integration of any function :math:`g` that are defined without
 requiring an analytical definition. In the scope of ``chaospy`` we limit this

--- a/chaospy/quad/collection/__init__.py
+++ b/chaospy/quad/collection/__init__.py
@@ -1,5 +1,5 @@
 # pylint: disable=wildcard-import
-"""
+r"""
 To create quadrature abscissas and weights, use the
 :func:`~chaospy.quad.generate_quadrature` function. Which type of quadrature to
 use is defined by the flag ``rule``. This argument can either be the full name,
@@ -20,6 +20,6 @@ or a single letter representing the rule. These are as follows.
 ``Patterson``, ``P``
     Gauss-Patterson quadrature rule. Nested. Valid to order 8.
 ``Fejer``, ``F``
-    Fejér quadrature. Same as Clenshaw-Curtis, but without the endpoints.
+    Fejer quadrature. Same as Clenshaw-Curtis, but without the endpoints.
 """
 from .frontend import *

--- a/chaospy/quad/collection/clenshaw_curtis.py
+++ b/chaospy/quad/collection/clenshaw_curtis.py
@@ -17,7 +17,7 @@ The first few orders with linear growth rule::
     >>> distribution = chaospy.Uniform(0, 1)
     >>> for order in [0, 1, 2, 3]:
     ...     X, W = chaospy.generate_quadrature(order, distribution, rule="C")
-    ...     print(order, numpy.around(X, 3), numpy.around(W, 3))
+    ...     print("{} {} {}".format(order, numpy.around(X, 3), numpy.around(W, 3)))
     0 [[0.5]] [1.]
     1 [[0. 1.]] [0.5 0.5]
     2 [[0.  0.5 1. ]] [0.167 0.667 0.167]
@@ -28,7 +28,7 @@ The first few orders with exponential growth rule::
     >>> for order in [0, 1, 2]:
     ...     X, W = chaospy.generate_quadrature(
     ...         order, distribution, rule="C", growth=True)
-    ...     print(order, numpy.around(X, 3), numpy.around(W, 3))
+    ...     print("{} {} {}".format(order, numpy.around(X, 3), numpy.around(W, 3)))
     0 [[0.5]] [1.]
     1 [[0.  0.5 1. ]] [0.167 0.667 0.167]
     2 [[0.    0.146 0.5   0.854 1.   ]] [0.033 0.267 0.4   0.267 0.033]
@@ -104,19 +104,35 @@ def _clenshaw_curtis(order, composite=None):
     Backend method.
 
     Examples:
-        >>> print(*_clenshaw_curtis(0))
-        [0.5] [1.]
-        >>> print(*_clenshaw_curtis(1))
-        [0. 1.] [0.5 0.5]
-        >>> print(*_clenshaw_curtis(2))
-        [0.  0.5 1. ] [0.16666667 0.66666667 0.16666667]
-        >>> print(*_clenshaw_curtis(3))
-        [0.   0.25 0.75 1.  ] [0.05555556 0.44444444 0.44444444 0.05555556]
-        >>> print(*_clenshaw_curtis(4), sep="\n")
+        >>> abscissas, weights = _clenshaw_curtis(0)
+        >>> print(abscissas)
+        [0.5]
+        >>> print(weights)
+        [1.]
+        >>> abscissas, weights = _clenshaw_curtis(1)
+        >>> print(abscissas)
+        [0. 1.]
+        >>> print(weights)
+        [0.5 0.5]
+        >>> abscissas, weights = _clenshaw_curtis(2)
+        >>> print(abscissas)
+        [0.  0.5 1. ]
+        >>> print(weights)
+        [0.16666667 0.66666667 0.16666667]
+        >>> abscissas, weights = _clenshaw_curtis(3)
+        >>> print(abscissas)
+        [0.   0.25 0.75 1.  ]
+        >>> print(weights)
+        [0.05555556 0.44444444 0.44444444 0.05555556]
+        >>> abscissas, weights = _clenshaw_curtis(4)
+        >>> print(abscissas)
         [0.         0.14644661 0.5        0.85355339 1.        ]
+        >>> print(weights)
         [0.03333333 0.26666667 0.4        0.26666667 0.03333333]
-        >>> print(*_clenshaw_curtis(5), sep="\n")
+        >>> abscissas, weights = _clenshaw_curtis(5)
+        >>> print(abscissas)
         [0.        0.0954915 0.3454915 0.6545085 0.9045085 1.       ]
+        >>> print(weights)
         [0.02       0.18037152 0.29962848 0.29962848 0.18037152 0.02      ]
     """
     if order == 0:

--- a/chaospy/quad/collection/fejer.py
+++ b/chaospy/quad/collection/fejer.py
@@ -13,7 +13,7 @@ The first few orders with linear growth rule::
     >>> distribution = chaospy.Uniform(0, 1)
     >>> for order in [0, 1, 2, 3]:
     ...     X, W = chaospy.generate_quadrature(order, distribution, rule="F")
-    ...     print(order, numpy.around(X, 3), numpy.around(W, 3))
+    ...     print("{} {} {}".format(order, numpy.around(X, 3), numpy.around(W, 3)))
     0 [[0.5]] [1.]
     1 [[0.25 0.75]] [0.5 0.5]
     2 [[0.146 0.5   0.854]] [0.286 0.429 0.286]
@@ -24,7 +24,7 @@ The first few orders with exponential growth rule::
     >>> for order in [0, 1, 2]:
     ...     X, W = chaospy.generate_quadrature(
     ...         order, distribution, rule="F", growth=True)
-    ...     print(order, numpy.around(X, 2), numpy.around(W, 2))
+    ...     print("{} {} {}".format(order, numpy.around(X, 2), numpy.around(W, 2)))
     0 [[0.5]] [1.]
     1 [[0.15 0.5  0.85]] [0.29 0.43 0.29]
     2 [[0.04 0.15 0.31 0.5  0.69 0.85 0.96]] [0.07 0.14 0.18 0.2  0.18 0.14 0.07]
@@ -102,20 +102,35 @@ def _fejer(order, composite=None):
     Backend method.
 
     Examples:
-        >>> print(*_fejer(0))
-        [0.5] [1.]
-        >>> print(*_fejer(1))
-        [0.25 0.75] [0.44444444 0.44444444]
-        >>> print(*_fejer(2))
-        [0.14644661 0.5        0.85355339] [0.26666667 0.4        0.26666667]
-        >>> print(*_fejer(3), sep="\n")
+        >>> abscissas, weights = _fejer(0)
+        >>> print(abscissas)
+        [0.5]
+        >>> print(weights)
+        [1.]
+        >>> abscissas, weights = _fejer(1)
+        >>> print(abscissas)
+        [0.25 0.75]
+        >>> print(weights)
+        [0.44444444 0.44444444]
+        >>> abscissas, weights = _fejer(2)
+        >>> print(abscissas)
+        [0.14644661 0.5        0.85355339]
+        >>> print(weights)
+        [0.26666667 0.4        0.26666667]
+        >>> abscissas, weights = _fejer(3)
+        >>> print(abscissas)
         [0.0954915 0.3454915 0.6545085 0.9045085]
+        >>> print(weights)
         [0.18037152 0.29962848 0.29962848 0.18037152]
-        >>> print(*_fejer(4), sep="\n")
+        >>> abscissas, weights = _fejer(4)
+        >>> print(abscissas)
         [0.0669873 0.25      0.5       0.75      0.9330127]
+        >>> print(weights)
         [0.12698413 0.22857143 0.26031746 0.22857143 0.12698413]
-        >>> print(*_fejer(5), sep="\n")
+        >>> abscissas, weights = _fejer(5)
+        >>> print(abscissas)
         [0.04951557 0.1882551  0.38873953 0.61126047 0.8117449  0.95048443]
+        >>> print(weights)
         [0.0950705  0.17612121 0.2186042  0.2186042  0.17612121 0.0950705 ]
     """
     order = int(order)

--- a/chaospy/quad/collection/fejer.py
+++ b/chaospy/quad/collection/fejer.py
@@ -1,5 +1,5 @@
 """
-Fejér quadrature method.
+Fejer quadrature method.
 
 The same method as :ref:`clenshaw_curtis`, but without the end-points. This
 makes this a better method for performing quadrature on infinite intervals, as
@@ -51,7 +51,7 @@ import chaospy.quad
 
 def quad_fejer(order, lower=0, upper=1, growth=False, part=None):
     """
-    Generate the quadrature abscisas and weights in Fejér quadrature.
+    Generate the quadrature abscissas and weights in Fejer quadrature.
 
     Example:
         >>> abscissas, weights = quad_fejer(3, 0, 1)

--- a/chaospy/quad/collection/gauss_legendre.py
+++ b/chaospy/quad/collection/gauss_legendre.py
@@ -19,7 +19,7 @@ The first few orders::
     >>> for order in [0, 1, 2, 3]:
     ...     abscissas, weights = chaospy.generate_quadrature(
     ...         order, distribution, rule="E")
-    ...     print(order, numpy.around(abscissas, 3), numpy.around(weights, 3))
+    ...     print("{} {} {}".format(order, numpy.around(abscissas, 3), numpy.around(weights, 3)))
     0 [[0.5]] [1.]
     1 [[0.211 0.789]] [0.5 0.5]
     2 [[0.113 0.5   0.887]] [0.278 0.444 0.278]
@@ -31,7 +31,7 @@ Using an alternative distribution::
     >>> for order in [0, 1, 2, 3]:
     ...     abscissas, weights = chaospy.generate_quadrature(
     ...         order, distribution, rule="E")
-    ...     print(order, numpy.around(abscissas, 3), numpy.around(weights, 3))
+    ...     print("{} {} {}".format(order, numpy.around(abscissas, 3), numpy.around(weights, 3)))
     0 [[0.5]] [1.]
     1 [[0.211 0.789]] [0.933 0.067]
     2 [[0.113 0.5   0.887]] [0.437 0.556 0.007]

--- a/chaospy/quad/collection/golub_welsch.py
+++ b/chaospy/quad/collection/golub_welsch.py
@@ -19,31 +19,31 @@ For example for the tailored quadrature rules defined above:
 * Gauss-Hermit quadrature is tailored to the normal (Gaussian) distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Normal(0, 1), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[-2.857 -1.356 -0.     1.356  2.857]] [0.011 0.222 0.533 0.222 0.011]
 
 * Gauss-Legendre quadrature is tailored to the Uniform distributions::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Uniform(0, 1), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[0.047 0.231 0.5   0.769 0.953]] [0.118 0.239 0.284 0.239 0.118]
 
 * Gauss-Jacobi quadrature is tailored to the Beta distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Beta(2, 4), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[0.067 0.212 0.41  0.627 0.827]] [0.118 0.367 0.36  0.139 0.015]
 
 * Gauss-Laguerre quadrature is tailored to the Exponential distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Exponential(), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[ 0.264  1.413  3.596  7.086 12.641]] [0.522 0.399 0.076 0.004 0.   ]
 
 * Generalized Gauss-Laguerre quadrature is tailored to the Gamma distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Gamma(2, 4), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[ 2.468  8.452 18.443 33.596 57.04 ]] [0.348 0.502 0.141 0.009 0.   ]
 
 For uncommon distributions an analytical Stieltjes method can not be performed
@@ -54,25 +54,25 @@ For example, to mention a few:
 * The triangle distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Triangle(), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[-0.821 -0.45  -0.     0.45   0.821]] [0.052 0.239 0.418 0.239 0.052]
 
 * The Laplace distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Laplace(), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[-8.091 -2.855 -0.     2.855  8.091]] [0.001 0.114 0.771 0.114 0.001]
 
 * The Weibull distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Weibull(), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[ 0.264  1.413  3.596  7.086 12.64 ]] [0.522 0.399 0.076 0.004 0.   ]
 
 * The Rayleigh distribution::
 
     >>> X, W = chaospy.generate_quadrature(4, chaospy.Rayleigh(), rule="G")
-    >>> print(numpy.around(X, 3), numpy.around(W, 3))
+    >>> print("{} {}".format(numpy.around(X, 3), numpy.around(W, 3)))
     [[0.308 0.938 1.779 2.79  4.032]] [0.144 0.453 0.339 0.063 0.002]
 
 As a small side note, it is worth noting that since the weight function is

--- a/chaospy/quad/collection/leja.py
+++ b/chaospy/quad/collection/leja.py
@@ -13,7 +13,7 @@ The first few orders::
     >>> for order in [0, 1, 2, 3, 4]:
     ...     abscissas, weights = chaospy.generate_quadrature(
     ...         order, distribution, rule="J")
-    ...     print(order, numpy.around(abscissas, 3), numpy.around(weights, 3))
+    ...     print("{} {} {}".format(order, numpy.around(abscissas, 3), numpy.around(weights, 3)))
     0 [[0.5]] [1.]
     1 [[0.5 1. ]] [1. 0.]
     2 [[0.  0.5 1. ]] [0.167 0.667 0.167]

--- a/tests/test_dist.py
+++ b/tests/test_dist.py
@@ -1,7 +1,6 @@
 """Testing basic distributions and their operations
 """
 import math
-from contextlib import suppress
 from inspect import isclass
 
 import numpy as np
@@ -16,9 +15,11 @@ DISTRIBUTIONS = ()
 for name in dir(collection):
     attr = getattr(collection, name)
     if isclass(attr) and issubclass(attr, cp.Dist):
-        with suppress(TypeError):
+        try:
             if len(attr()) == 1:
                 DISTRIBUTIONS = DISTRIBUTIONS + (attr,)
+        except TypeError:
+            pass
 
 @pytest.fixture(params=DISTRIBUTIONS)
 def distribution(request):


### PR DESCRIPTION
Chaospy release v3 broke python2. This adds support back (for the time being).

Along the way mande some changes to CircleCI:
* Run tests for both py2 and py3 so we don't make the same mistake twice.
* Remove virtualenv (which is python version specific) and use native docker