### PR TITLE
Speed up sort_key with built-ins

### DIFF
--- a/chaospy/poly/base.py
+++ b/chaospy/poly/base.py
@@ -407,7 +407,10 @@ class Poly(object):
         out = numpy.array(self.keys)
         return out
 
-
 def sort_key(val):
     """Sort key for sorting keys in grevlex order."""
-    return numpy.sum((max(val)+1)**numpy.arange(len(val)-1, -1, -1)*val)
+    maxval = max(val)
+    lenval = len(val)
+    exponents = range(lenval-1, -1, -1)
+    r = [(maxval+1)**expo*val[lenval-1-expo] for expo in exponents]
+    return sum(r)


### PR DESCRIPTION
For sparse grids, as in #157, changing from numpy to using only built-in list functions of Python for key sorting gives a speed-up of ~30%. Functionality and speed-up have been verified for the given example of #157 in 3D (0.2 vs 0.3 s) and 7D (5.3 vs 7.5 s). 