### PR TITLE
Adding support for segmented TTR

### DIFF
--- a/chaospy/__init__.py
+++ b/chaospy/__init__.py
@@ -29,14 +29,21 @@ from chaospy.descriptives import *
 from chaospy.regression import *
 from chaospy.external import *
 
-LOGPATH = os.environ.get("CHAOSPY_LOGPATH", os.devnull)
-logging.basicConfig(level=logging.DEBUG, filename=LOGPATH, filemode="w")
-streamer = logging.StreamHandler()
-streamer.setLevel(logging.DEBUG)
-logger = logging.getLogger(__name__)
-logger.addHandler(streamer)
-
 try:
     __version__ = pkg_resources.get_distribution("chaospy").version
 except pkg_resources.DistributionNotFound:
-    pass
+    __version__ = None
+
+
+def configure_logging():
+    """Configure logging for Chaospy."""
+    logpath = os.environ.get("CHAOSPY_LOGPATH", os.devnull)
+    logging.basicConfig(level=logging.DEBUG, filename=logpath, filemode="w")
+    streamer = logging.StreamHandler()
+    loglevel = logging.DEBUG if os.environ.get("CHAOSPY_DEBUG", "") else logging.WARNING
+    streamer.setLevel(loglevel)
+
+    logger = logging.getLogger(__name__)
+    logger.addHandler(streamer)
+
+configure_logging()

--- a/chaospy/distributions/collection/bradford.py
+++ b/chaospy/distributions/collection/bradford.py
@@ -54,9 +54,6 @@ class Bradford(Add):
         array([5.171 , 4.1748, 5.8704, 4.8192])
         >>> distribution.mom(1).round(4)
         4.9026
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[5.0195, 5.0028, 5.0009],
-               [0.3314, 0.2664, 0.2571]])
     """
     def __init__(self, shape=1, lower=0, upper=1):
         self._repr = {"shape": shape, "lower": lower, "upper": upper}

--- a/chaospy/distributions/collection/chi.py
+++ b/chaospy/distributions/collection/chi.py
@@ -57,9 +57,6 @@ class Chi(Add):
         array([ 6.8244,  2.9773, 10.8003,  5.5892])
         >>> distribution.mom(1).round(4)
         6.0133
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 7.6671,  9.0688, 10.2809],
-               [ 6.8673, 12.6824, 18.2126]])
     """
 
     def __init__(self, df=1, scale=1, shift=0):
@@ -93,9 +90,6 @@ class Maxwell(Add):
         array([6.6381, 4.6119, 8.5955, 6.015 ])
         >>> distribution.mom(1).round(4)
         6.1915
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[6.8457, 7.4421, 7.9834],
-               [1.8141, 3.3964, 4.8716]])
     """
 
     def __init__(self, scale=1, shift=0):
@@ -128,9 +122,6 @@ class Rayleigh(Add):
         array([5.9122, 3.9886, 7.9001, 5.2946])
         >>> distribution.mom(1).round(4)
         5.5066
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[6.3336, 7.0344, 7.6405],
-               [1.7168, 3.1706, 4.5532]])
     """
     def __init__(self, scale=1, shift=0):
         self._repr = {"scale": scale, "shift": shift}

--- a/chaospy/distributions/collection/chi_squared.py
+++ b/chaospy/distributions/collection/chi_squared.py
@@ -64,9 +64,6 @@ class ChiSquared(Add):
         array([14.0669,  2.595 , 35.6294,  9.2851])
         >>> distribution.mom(1).round(4)
         13.0001
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 33.    ,  51.6667,  69.8042],
-               [128.    , 432.    , 895.9999]])
     """
 
     def __init__(self, df=1, scale=1, shift=0, nc=0):

--- a/chaospy/distributions/collection/exponential_power.py
+++ b/chaospy/distributions/collection/exponential_power.py
@@ -58,9 +58,6 @@ class ExponentialPower(Add):
         array([2.7003, 1.679 , 3.3551, 2.4223])
         >>> distribution.mom(1).round(4)
         2.4314
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[2.3851, 2.4491, 2.5043],
-               [0.3363, 0.4539, 0.5185]])
     """
 
     def __init__(self, shape=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/exponential_weibull.py
+++ b/chaospy/distributions/collection/exponential_weibull.py
@@ -56,9 +56,6 @@ class ExponentialWeibull(Add):
         array([3.5711, 2.2872, 4.8376, 3.1776])
         >>> distribution.mom(1).round(4)
         3.2916
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[3.731 , 4.1391, 4.5115],
-               [0.7486, 1.4897, 2.2135]])
     """
     def __init__(self, alpha=1, kappa=1, scale=1, shift=0):
         self._repr = {

--- a/chaospy/distributions/collection/folded_normal.py
+++ b/chaospy/distributions/collection/folded_normal.py
@@ -53,9 +53,6 @@ class FoldedNormal(Add):
         array([2.1633, 1.7827, 4.6911, 5.5156])
         >>> distribution.mom(1).round(4)
         5.034
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[5.3928, 6.0914, 6.7954],
-               [3.7271, 6.2602, 7.926 ]])
     """
 
     def __init__(self, mu=0, sigma=1, loc=0):

--- a/chaospy/distributions/collection/frechet.py
+++ b/chaospy/distributions/collection/frechet.py
@@ -55,9 +55,6 @@ class Frechet(Add):
         array([3.0393, 1.9924, 3.8849, 2.7397])
         >>> distribution.mom(1).round(4)
         3.7082
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[2.8951, 3.039 , 3.1808],
-               [0.4213, 0.7168, 0.9441]])
     """
 
     def __init__(self, shape=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/generalized_gamma.py
+++ b/chaospy/distributions/collection/generalized_gamma.py
@@ -64,9 +64,6 @@ class GeneralizedGamma(Add):
         array([5.6691, 4.1674, 7.0214, 5.2264])
         >>> distribution.mom(1).round(4)
         3.477
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[5.6341, 5.9361, 6.2271],
-               [0.9553, 1.8381, 2.6689]])
     """
 
     def __init__(self, shape1, shape2, scale, shift):

--- a/chaospy/distributions/collection/gompertz.py
+++ b/chaospy/distributions/collection/gompertz.py
@@ -53,9 +53,6 @@ class Gompertz(Add):
         array([2.6052, 2.0798, 3.3868, 2.3967])
         >>> distribution.mom(1).round(4)
         2.5242
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[3.034 , 3.3243, 3.5329],
-               [0.1878, 0.3655, 0.5218]])
     """
 
     def __init__(self, shape, scale, shift):

--- a/chaospy/distributions/collection/hyperbolic_secant.py
+++ b/chaospy/distributions/collection/hyperbolic_secant.py
@@ -53,9 +53,6 @@ class HyperbolicSecant(Add):
         array([ 2.6397, -0.1648,  5.2439,  1.9287])
         >>> distribution.mom(1).round(4)
         2.0
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 2.    ,  2.    ,  2.    ],
-               [ 4.    , 16.0001, 35.9976]])
     """
 
     def __init__(self, loc=0, scale=1):

--- a/chaospy/distributions/collection/kumaraswamy.py
+++ b/chaospy/distributions/collection/kumaraswamy.py
@@ -62,9 +62,6 @@ class Kumaraswamy(Add):
         array([2.6414, 2.2434, 2.8815, 2.5295])
         >>> distribution.mom(1).round(4)
         2.5333
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[2.5056, 2.5018, 2.5008],
-               [0.0489, 0.0569, 0.0595]])
     """
 
     def __init__(self, alpha, beta, lower=0, upper=1):

--- a/chaospy/distributions/collection/log_gamma.py
+++ b/chaospy/distributions/collection/log_gamma.py
@@ -50,9 +50,6 @@ class LogGamma(Add):
         array([ 2.6074, -0.0932,  4.1166,  1.9675])
         >>> distribution.mom(1).round(4)
         1.8456
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 0.5924, -0.8925, -2.5379],
-               [ 2.5797,  6.6525, 12.5947]])
     """
 
     def __init__(self, shape=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/log_uniform.py
+++ b/chaospy/distributions/collection/log_uniform.py
@@ -60,9 +60,6 @@ class LogUniform(Add):
         array([31.4099, 19.5793, 41.2227, 26.9349])
         >>> distribution.mom(1).round(4)
         28.393
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[30.8948, 30.5352, 30.4949],
-               [52.8588, 42.8862, 41.419 ]])
     """
 
     def __init__(self, lower=0, upper=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/log_weibull.py
+++ b/chaospy/distributions/collection/log_weibull.py
@@ -48,9 +48,6 @@ class LogWeibull(Add):
         array([3.71  , 0.4572, 7.952 , 2.631 ])
         >>> distribution.mom(1).round(4)
         3.1544
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 6.0775,  9.5552, 13.213 ],
-               [ 6.5797, 20.4065, 42.3767]])
     """
     def __init__(self, scale=1, loc=0):
         self._repr = {"scale": scale, "loc": loc}

--- a/chaospy/distributions/collection/nakagami.py
+++ b/chaospy/distributions/collection/nakagami.py
@@ -52,9 +52,6 @@ class Nakagami(Add):
         array([4.1137, 3.076 , 5.0824, 3.8012])
         >>> distribution.mom(1).round(4)
         3.88
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[4.1568, 4.4181, 4.6622],
-               [0.4657, 0.8824, 1.2706]])
     """
 
     def __init__(self, shape=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/power_normal.py
+++ b/chaospy/distributions/collection/power_normal.py
@@ -51,9 +51,6 @@ class PowerNormal(Add):
         array([ 1.5523, -1.122 ,  3.5244,  0.8368])
         >>> distribution.mom(1).round(4)
         0.8716
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[0.6455, 0.4421, 0.2628],
-               [2.7268, 5.5707, 8.4597]])
     """
 
     def __init__(self, shape=1, mu=0, scale=1):

--- a/chaospy/distributions/collection/reciprocal.py
+++ b/chaospy/distributions/collection/reciprocal.py
@@ -30,9 +30,6 @@ class Reciprocal(Dist):
         array([3.1462, 2.166 , 3.8645, 2.7937])
         >>> distribution.mom(1).round(4)
         7.8433
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[3.023 , 3.0033, 3.0011],
-               [0.3307, 0.2664, 0.257 ]])
     """
 
     def __init__(self, lower=1, upper=2):

--- a/chaospy/distributions/collection/trunc_exponential.py
+++ b/chaospy/distributions/collection/trunc_exponential.py
@@ -56,9 +56,6 @@ class TruncExponential(Add):
         array([1.1891, 0.1852, 1.873 , 0.8415])
         >>> distribution.mom(1).round(4)
         0.917
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[1.0163, 1.0024, 1.0008],
-               [0.3292, 0.2671, 0.2572]])
     """
 
     def __init__(self, upper=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/tukey_lambda.py
+++ b/chaospy/distributions/collection/tukey_lambda.py
@@ -65,9 +65,6 @@ class TukeyLambda(Add):
         array([ 3.2697, -2.0812,  7.9008,  1.8575])
         >>> distribution.mom(1).round(4)
         2.0
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 2.    ,  2.    ,  2.    ],
-               [13.1595, 42.1102, 91.3601]])
     """
 
     def __init__(self, shape=0, scale=1, shift=0):

--- a/chaospy/distributions/collection/weibull.py
+++ b/chaospy/distributions/collection/weibull.py
@@ -58,9 +58,6 @@ class Weibull(Add):
         array([1.0296, 0.3495, 1.7325, 0.8113])
         >>> distribution.mom(1).round(4)
         0.8862
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[1.1786, 1.4264, 1.6407],
-               [0.2146, 0.3963, 0.5691]])
     """
 
     def __init__(self, shape=1, scale=1, shift=0):

--- a/chaospy/distributions/collection/wrapped_cauchy.py
+++ b/chaospy/distributions/collection/wrapped_cauchy.py
@@ -78,9 +78,6 @@ class WrappedCauchy(Add):
         array([29.4606,  6.3357, 30.9928, 14.8313])
         >>> distribution.mom(1).round(4)
         18.5664
-        >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[ 18.5664,  18.5664,  18.5664],
-               [121.4247,  12.6649,  47.0276]])
     """
 
     def __init__(self, shape=0.5, scale=1, shift=0):

--- a/chaospy/distributions/evaluation/recurrence_coefficients.py
+++ b/chaospy/distributions/evaluation/recurrence_coefficients.py
@@ -77,21 +77,9 @@ def evaluate_recurrence_coefficients(
         if cache_key(distribution) in cache:
             return cache[cache_key(distribution)]
 
-    try:
-        parameters = load_parameters(
-            distribution, "_ttr", parameters, cache, cache_key)
-        coeff1, coeff2 = distribution._ttr(k_data, **parameters)
-
-    except NotImplementedError:
-        from ...quadrature import generate_quadrature
-        from ...quadrature.recurrence.stieltjes import discretized_stieltjes
-        abscissas, weights = generate_quadrature(
-            100, distribution, rule="clenshaw_curtis")
-        (coeff1, coeff2), _, _ = discretized_stieltjes(
-            numpy.max(k_data), abscissas, weights, normed=False)
-        range_ = numpy.arange(len(distribution), dtype=int)
-        coeff1 = coeff1[range_, k_data]
-        coeff2 = coeff2[range_, k_data]
+    parameters = load_parameters(
+        distribution, "_ttr", parameters, cache, cache_key)
+    coeff1, coeff2 = distribution._ttr(k_data, **parameters)
 
     out = numpy.zeros((2,) + k_data.shape)
     out.T[:, 0] = numpy.asarray(coeff1).T

--- a/chaospy/distributions/evaluation/recurrence_coefficients.py
+++ b/chaospy/distributions/evaluation/recurrence_coefficients.py
@@ -22,16 +22,6 @@ The use of cache::
 
     >>> evaluate_recurrence_coefficients(dist, k_data, cache={((2,), dist): (3., 4.)})
     (3.0, 4.0)
-
-Approximate with the use of density, forward, inverse and bound function if recurrence function is missing::
-
-    >>> class Exponential(chaospy.Dist):
-    ...     _pdf = lambda self, x_data, alpha: alpha*numpy.e**(-alpha*x_data)
-    ...     _cdf = lambda self, x_data, alpha: 1-numpy.e**(-alpha*x_data)
-    ...     _ppf = lambda self, u_data, alpha: -numpy.log(1-u_data)/alpha
-    >>> dist = Exponential(alpha=2)
-    >>> evaluate_recurrence_coefficients(dist, k_data).round(3)
-    array([2.5, 1. ])
 """
 import logging
 

--- a/chaospy/distributions/operators/logarithm.py
+++ b/chaospy/distributions/operators/logarithm.py
@@ -30,9 +30,6 @@ class Logn(UnaryOperator):
         [0.4578 0.0991 0.608  0.3582]
         >>> print(numpy.around(distribution.mom(1), 4))
         0.3516
-        >>> print(numpy.around(distribution.ttr([0, 1, 2]), 4))
-        [[0.3516 0.3085 0.3144]
-         [1.     0.0324 0.0266]]
     """
 
     def __init__(self, dist, base=2):

--- a/chaospy/poly/__init__.py
+++ b/chaospy/poly/__init__.py
@@ -98,11 +98,11 @@ from .setdim import setdim
 
 from numpoly import (
     abs, absolute, add, any, all, allclose, around, aspolynomial, atleast_1d,
-    atleast_2d, atleast_3d, call, ceil, concatenate, cumsum, decompose, diff,
-    divide, dstack, equal, floor, gradient, hessian, hstack, inner, isclose,
-    isconstant, isfinite, multiply, ndpoly, negative, not_equal, outer,
-    polynomial, positive, power, prod, repeat, rint, round, square, stack,
-    subtract, sum, vstack,
+    atleast_2d, atleast_3d, bindex, call, ceil, concatenate, cumsum, decompose,
+    diff, divide, dstack, equal, floor, gradient, hessian, hstack, inner,
+    isclose, isconstant, isfinite, multiply, ndpoly, negative, not_equal,
+    outer, polynomial, positive, power, prod, repeat, rint, round, square,
+    stack, subtract, sum, vstack,
 )
 
 @wraps(polynomial)

--- a/chaospy/quadrature/frontend.py
+++ b/chaospy/quadrature/frontend.py
@@ -86,6 +86,7 @@ def generate_quadrature(
         sparse=False,
         accuracy=100,
         growth=None,
+        segments=1,
         recurrence_algorithm="",
 ):
     """
@@ -110,6 +111,11 @@ def generate_quadrature(
             If True sets the growth rule for the quadrature rule to only
             include orders that enhances nested samples. Defaults to the same
             value as ``sparse`` if omitted.
+        segments (int):
+            Split intervals into N subintervals and create a patched
+            quadrature based on the segmented quadrature. Can not be lower than
+            `order`. If 0 is provided, default to square root of `order`.
+            Nested samples only exist when the number of segments are fixed.
         recurrence_algorithm (str):
             Name of the algorithm used to generate abscissas and weights in
             case of Gaussian quadrature scheme. If omitted, ``analytical`` will
@@ -149,7 +155,7 @@ def generate_quadrature(
     kwargs = {}
 
     if rule in ("clenshaw_curtis", "fejer", "newton_cotes"):
-        kwargs.update(growth=growth)
+        kwargs.update(growth=growth, segments=segments)
 
     if rule in ("gaussian", "gauss_kronrod", "gauss_radau", "gauss_lobatto"):
         kwargs.update(accuracy=accuracy,

--- a/chaospy/quadrature/gaussian.py
+++ b/chaospy/quadrature/gaussian.py
@@ -97,7 +97,7 @@ For example, to mention a few:
     >>> abscissas, weights = chaospy.generate_quadrature(
     ...     5, distribution, rule="gaussian")
     >>> abscissas.round(4)
-    array([[ 0.2228,  1.1886,  2.9918,  5.7731,  9.8334, 15.9737]])
+    array([[ 0.2242,  1.19  ,  2.9933,  5.7746,  9.8349, 15.9752]])
     >>> weights.round(4)
     array([4.589e-01, 4.170e-01, 1.134e-01, 1.040e-02, 3.000e-04, 0.000e+00])
 

--- a/chaospy/quadrature/gaussian.py
+++ b/chaospy/quadrature/gaussian.py
@@ -111,7 +111,6 @@ For example, to mention a few:
     >>> weights.round(4)
     array([9.600e-02, 3.591e-01, 3.891e-01, 1.412e-01, 1.430e-02, 2.000e-04])
 """
-from ..distributions import evaluation
 from .recurrence import (
     construct_recurrence_coefficients, coefficients_to_quadrature)
 from .combine import combine_quadrature

--- a/chaospy/quadrature/gaussian.py
+++ b/chaospy/quadrature/gaussian.py
@@ -111,6 +111,7 @@ For example, to mention a few:
     >>> weights.round(4)
     array([9.600e-02, 3.591e-01, 3.891e-01, 1.412e-01, 1.430e-02, 2.000e-04])
 """
+from ..distributions import evaluation
 from .recurrence import (
     construct_recurrence_coefficients, coefficients_to_quadrature)
 from .combine import combine_quadrature
@@ -120,7 +121,7 @@ def quad_gaussian(
         order,
         dist,
         rule="fejer",
-        accuracy=100,
+        accuracy=200,
         recurrence_algorithm="",
 ):
     """

--- a/chaospy/quadrature/newton_cotes.py
+++ b/chaospy/quadrature/newton_cotes.py
@@ -45,13 +45,18 @@ Applying Smolyak sparse grid on Newton-Cotes::
     array([ 0.028,  0.022,  0.028,  0.356,  0.022,  0.356, -0.622,  0.356,
             0.022,  0.356,  0.028,  0.022,  0.028])
 """
+from __future__ import division
+try:
+    from functools import lru_cache
+except ImportError:
+    from functools32 import lru_cache
 import numpy
 from scipy.integrate import newton_cotes
 
 from .combine import combine_quadrature
 
 
-def quad_newton_cotes(order, domain=(0, 1), growth=False):
+def quad_newton_cotes(order, domain=(0, 1), growth=False, segments=1):
     """
     Generate the abscissas and weights in Newton-Cotes quadrature.
 
@@ -63,6 +68,11 @@ def quad_newton_cotes(order, domain=(0, 1), growth=False):
         growth (bool):
             If True sets the growth rule for the quadrature rule to only
             include orders that enhances nested samples.
+        segments (int):
+            Split intervals into N subintervals and create a patched
+            quadrature based on the segmented quadrature. Can not be lower than
+            `order`. If 0 is provided, default to square root of `order`.
+            Nested samples only exist when the number of segments are fixed.
 
     Returns:
         (numpy.ndarray, numpy.ndarray):
@@ -74,11 +84,16 @@ def quad_newton_cotes(order, domain=(0, 1), growth=False):
                 The quadrature weights with ``weights.shape == (N,)``.
 
     Examples:
-        >>> abscissas, weights = quad_newton_cotes(3)
+        >>> abscissas, weights = quad_newton_cotes(4)
         >>> abscissas.round(4)
-        array([[0.    , 0.3333, 0.6667, 1.    ]])
+        array([[0.  , 0.25, 0.5 , 0.75, 1.  ]])
         >>> weights.round(4)
-        array([0.375, 1.125, 1.125, 0.375])
+        array([0.0778, 0.3556, 0.1333, 0.3556, 0.0778])
+        >>> abscissas, weights = quad_newton_cotes(4, segments=2)
+        >>> abscissas.round(4)
+        array([[0.  , 0.25, 0.5 , 0.75, 1.  ]])
+        >>> weights.round(4)
+        array([0.1667, 0.6667, 0.3333, 0.6667, 0.1667])
     """
     from ..distributions.baseclass import Dist
     if isinstance(domain, Dist):
@@ -93,23 +108,50 @@ def quad_newton_cotes(order, domain=(0, 1), growth=False):
     lower = numpy.asarray(lower).flatten()
     upper = numpy.asarray(upper).flatten()
     dim = max(lower.size, upper.size, order.size)
-    order = numpy.ones(dim, dtype=int)*order
-    lower = numpy.ones(dim)*lower
-    upper = numpy.ones(dim)*upper
+
+    order = order*numpy.ones(dim, dtype=int)
+    lower = lower*numpy.ones(dim)
+    upper = upper*numpy.ones(dim)
+    segments = segments*numpy.ones(dim, dtype=int)
 
     results = [_newton_cotes(*args, growth=growth)
-               for args in zip(order, lower, upper)]
+               for args in zip(order, lower, upper, segments)]
     abscissas = [args[0] for args in results]
     weights = [args[1] for args in results]
     return combine_quadrature(abscissas, weights)
 
 
-def _newton_cotes(order, lower, upper, growth):
+@lru_cache(None)
+def _newton_cotes(order, lower, upper, segments=1, growth=False):
     """Backend for Newton-Cotes quadrature rule."""
     if order == 0:
         return numpy.array([0.5*(lower+upper)]), numpy.ones(1)
     order = 2**order if growth else order
+
+    if segments != 1 and order > 2:
+        if not segments:
+            segments = int(numpy.sqrt(order))
+        assert segments < order, "few samples to distribute than intervals"
+        abscissas = []
+        weights = []
+
+        nodes = numpy.linspace(0, 1, segments+1)
+        for lower, upper in zip(nodes[:-1], nodes[1:]):
+
+            abscissa, weight = _newton_cotes(order//segments, lower, upper)
+            weight = weight*(upper-lower)
+            if abscissas:
+                weights[-1] += weight[0]
+                abscissa = abscissa[1:]
+                weight = weight[1:]
+            abscissas.extend(abscissa)
+            weights.extend(weight)
+
+        assert len(abscissas) == order+1
+        assert len(weights) == order+1
+        return numpy.array(abscissas), numpy.array(weights)
+
     return (
         numpy.linspace(lower, upper, order+1),
-        newton_cotes(order)[0]/(upper-lower),
+        newton_cotes(order)[0]/(upper-lower)/order,
     )

--- a/chaospy/quadrature/recurrence/frontend.py
+++ b/chaospy/quadrature/recurrence/frontend.py
@@ -69,7 +69,7 @@ def construct_recurrence_coefficients(
         >>> coefficients = chaospy.construct_recurrence_coefficients(
         ...     4, distribution, recurrence_algorithm="stieltjes")
         >>> coefficients[0].round(4)
-        array([[-0.,  0., -0.,  0., -0.],
+        array([[-0.,  0.,  0., -0.,  0.],
                [ 1.,  1.,  2.,  3.,  4.]])
         >>> distribution = chaospy.J(chaospy.Exponential(), chaospy.Uniform())
         >>> coefficients = chaospy.construct_recurrence_coefficients(

--- a/chaospy/quadrature/recurrence/frontend.py
+++ b/chaospy/quadrature/recurrence/frontend.py
@@ -13,7 +13,7 @@ def construct_recurrence_coefficients(
         order,
         dist,
         rule="fejer",
-        accuracy=100,
+        accuracy=200,
         recurrence_algorithm="",
 ):
     """
@@ -109,12 +109,14 @@ def construct_recurrence_coefficients(
 
     elif recurrence_algorithm == "lanczos":
         from ..frontend import generate_quadrature
-        abscissas, weights = generate_quadrature(accuracy, dist, rule=rule)
+        abscissas, weights = generate_quadrature(
+            accuracy, dist, rule=rule, segments=0)
         coeffs = lanczos(order, abscissas, weights)
 
     elif recurrence_algorithm == "stieltjes":
         from ..frontend import generate_quadrature
-        abscissas, weights = generate_quadrature(accuracy, dist, rule=rule)
+        abscissas, weights = generate_quadrature(
+            accuracy, dist, rule=rule, segments=0)
         coeffs, _, _ = discretized_stieltjes(order, abscissas, weights)
 
     return [coeffs.reshape(2, int(order)+1)]

--- a/conftest.py
+++ b/conftest.py
@@ -1,44 +1,24 @@
-# pylint: disable=redefined-outer-name
 """Global configuration."""
 import os
-import shutil
 
 import pytest
 
-
-@pytest.fixture(scope="session")
-def workspace_folder(tmpdir_factory):
-    """Path to pytest workspace directory."""
-    path = str(tmpdir_factory.mktemp("workspace"))
-    yield path
-    shutil.rmtree(path)
-
-
-@pytest.fixture(scope="session")
-def global_setup(workspace_folder):
-    """Global configuration setup."""
-    del workspace_folder
+import numpy
+import scipy
+import chaospy
 
 
 @pytest.fixture(autouse=True)
-def workspace(global_setup, workspace_folder, doctest_namespace):
-    """Folder to work from for each test."""
-    del global_setup # to please the pylint Gods.
-
-    # give access to expected modules in all doctest:
-    import numpy
+def global_setup(doctest_namespace, monkeypatch):
+    """Global configuration setup."""
     doctest_namespace["numpy"] = numpy
-    import scipy
     doctest_namespace["scipy"] = scipy
-    import chaospy
     doctest_namespace["chaospy"] = chaospy
 
     # fix random seeds:
-    from numpy.random import seed
-    seed(1000)
+    numpy.random.seed(1000)
 
-    # change to workspace for the duration of test:
-    curdir = os.path.abspath(os.path.curdir)
-    os.chdir(workspace_folder)
-    yield workspace_folder
-    os.chdir(curdir)
+    # set debug mode during testing
+    environ = os.environ.copy()
+    environ["NUMPOLY_DEBUG"] = True
+    monkeypatch.setattr("os.environ", environ)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "chaospy"
-version = "3.2.4"
+version = "3.2.5"
 description = "Numerical tool for perfroming uncertainty quantification"
 license = "MIT"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
* Adding segmenting to clenshaw-curtis, fejer and newton-cotes

* Add segement to generate_quadrature frontend
* Bugfix to Newton-cotes (weights were wrong)
* Add LRU-cache to increase speed
* Remove auto-approximation of TTR when NotImplementedError occurs. Instead let `generate_quadrature` do the work, which has more detaled controll. Lots of doc-tests suddenly doesn't make sense.