### PR TITLE
Add trunc dists to docs

### DIFF
--- a/docs/distributions/collection.rst
+++ b/docs/distributions/collection.rst
@@ -273,6 +273,16 @@ Triangle Distribution
 
 .. autoclass:: chaospy.distributions.collection.triangle.Triangle
 
+Truncated Normal Distribution
+-----------------------------
+
+.. autoclass:: chaospy.distributions.collection.trunc_normal.TruncNormal
+
+Truncated Exponential Distribution
+----------------------------------
+
+.. autoclass:: chaospy.distributions.collection.trunc_exponential.TruncExponential
+
 Tukey-Lambda Distribution
 -------------------------
 

--- a/docs/distributions/collection.rst
+++ b/docs/distributions/collection.rst
@@ -11,7 +11,7 @@ List of Distributions
 
         >>> upper_truncated_weibull = chaospy.Weibull(1, 1) < 2
         >>> print(upper_truncated_weibull)
-        Trunc(Weibull(scale=1, shape=1, shift=0), 2))
+        Trunc(Weibull(scale=1, shape=1, shift=0), 2)
         >>> upper_and_lower_truncated_weibull = upper_truncated_weibull > 0.5
         >>> print(upper_and_lower_truncated_weibull)
         Trunc(0.5, Trunc(Weibull(scale=1, shape=1, shift=0), 2))

--- a/docs/distributions/collection.rst
+++ b/docs/distributions/collection.rst
@@ -9,12 +9,12 @@ List of Distributions
 
     .. code-block::
 
-        >>> upper_truncated_weibull = chaospy.Weibull(1.0,1.0) < 2.0
+        >>> upper_truncated_weibull = chaospy.Weibull(1, 1) < 2
         >>> print(upper_truncated_weibull)
-        Trunc(Weibull(scale=1, shape=1, shift=0), 2.0))
+        Trunc(Weibull(scale=1, shape=1, shift=0), 2))
         >>> upper_and_lower_truncated_weibull = upper_truncated_weibull > 0.5
         >>> print(upper_and_lower_truncated_weibull)
-        Trunc(0.5, Trunc(Weibull(scale=1, shape=1, shift=0), 2.0))
+        Trunc(0.5, Trunc(Weibull(scale=1, shape=1, shift=0), 2))
 
 Alpha Distribution
 ------------------

--- a/docs/distributions/collection.rst
+++ b/docs/distributions/collection.rst
@@ -3,6 +3,19 @@
 List of Distributions
 =====================
 
+.. note::
+    Note that distributions for which there is no specific truncated variant,
+    can be truncated using the generic truncation feature, i.e.
+
+    .. code-block::
+
+        >>> upper_truncated_weibull = chaospy.Weibull(1.0,1.0) < 2.0
+        >>> print(upper_truncated_weibull)
+        Trunc(Weibull(scale=1, shape=1, shift=0), 2.0))
+        >>> upper_and_lower_truncated_weibull = upper_truncated_weibull > 0.5
+        >>> print(upper_and_lower_truncated_weibull)
+        Trunc(0.5, Trunc(Weibull(scale=1, shape=1, shift=0), 2.0))
+
 Alpha Distribution
 ------------------
 


### PR DESCRIPTION
Hi, this is related to https://github.com/jonathf/chaospy/issues/250

I think the 1st commit; 02956a7, confirms to what you proposed.
On the 2nd commit; 1759a43, today I did not have time to create a new notebook for this generic truncation topic with illustrative plots ect, hence i have just added this note in the rst for now. But if you prefer that a notebook is created instead, we can discard the present commit, and i can try to create a notebook when i have time again.