### PR TITLE
Refactor Discrete Distribution handling

### DIFF
--- a/chaospy/distributions/baseclass.py
+++ b/chaospy/distributions/baseclass.py
@@ -150,6 +150,9 @@ class Dist(object):
         if len(self) > 1 and evaluation.get_dependencies(*self):
             raise StochasticallyDependentError(
                 "Cumulative distribution does not support dependencies.")
+        x_data = numpy.asarray(x_data)
+        if self.interpret_as_integer:
+            x_data = x_data+0.5
         q_data = self.fwd(x_data)
         if len(self) > 1:
             q_data = numpy.prod(q_data, 0)
@@ -298,7 +301,7 @@ class Dist(object):
                 out = out.reshape(dim, int(out.size/dim))
 
         if self.interpret_as_integer:
-            out = out.astype(int)
+            out = numpy.round(out).astype(int)
         return out
 
     def mom(self, K, **kws):

--- a/chaospy/distributions/collection/binomial.py
+++ b/chaospy/distributions/collection/binomial.py
@@ -14,23 +14,30 @@ class Binomial(Dist):
         comb(N, x) p^x (1-p)^{N-x}      x in {0, 1, ..., N}
 
     Examples:
-        >>> distribution = chaospy.Binomial(5, 0.5)
+        >>> distribution = chaospy.Binomial(3, 0.5)
         >>> distribution
-        Binomial(prob=0.5, size=5)
+        Binomial(prob=0.5, size=3)
+        >>> distribution.pdf([0, 1, 2, 3]).round(4)
+        array([0.125, 0.375, 0.375, 0.125])
+        >>> distribution.cdf([0, 1, 2, 3]).round(4)
+        array([0.125, 0.5  , 0.875, 1.   ])
+        >>> distribution.fwd([-0.5, -0.49, 0, 0.49, 0.5]).round(4)
+        array([0.    , 0.0013, 0.0625, 0.1238, 0.125 ])
         >>> q = numpy.linspace(0, 1, 8)
-        >>> distribution.inv(q)
-        array([0, 1, 2, 2, 3, 3, 4, 5])
-        >>> distribution.fwd(distribution.inv(q)).round(4)
-        array([0.0312, 0.1875, 0.5   , 0.5   , 0.8125, 0.8125, 0.9688, 1.    ])
-        >>> distribution.pdf(distribution.inv(q)).round(4)
-        array([0.0312, 0.1562, 0.3125, 0.3125, 0.3125, 0.3125, 0.1562, 0.0312])
+        >>> q.round(2)
+        array([0.  , 0.14, 0.29, 0.43, 0.57, 0.71, 0.86, 1.  ])
+        >>> distribution.inv(q).round(2)
+        array([-0.5 ,  0.55,  0.93,  1.31,  1.69,  2.07,  2.45,  3.5 ])
+        >>> distribution.fwd(distribution.inv(q)).round(2)
+        array([0.  , 0.14, 0.29, 0.43, 0.57, 0.71, 0.86, 1.  ])
         >>> distribution.sample(10)
-        array([3, 1, 4, 2, 4, 2, 1, 2, 2, 4])
+        array([3, 1, 2, 1, 0, 2, 2, 2, 2, 3])
         >>> distribution.mom([1, 2, 3]).round(4)
-        array([ 2.5,  7.5, 25. ])
+        array([1.5 , 3.  , 6.75])
         >>> distribution.ttr([1, 2, 3]).round(4)
-        array([[2.5 , 2.5 , 2.5 ],
-               [1.25, 2.  , 2.25]])
+        array([[1.5 , 1.5 , 1.5 ],
+               [0.75, 1.  , 0.75]])
+
     """
     interpret_as_integer = True
 
@@ -39,19 +46,38 @@ class Binomial(Dist):
         Dist.__init__(self, size=size, prob=prob)
 
     def _cdf(self, x_data, size, prob):
-        return special.bdtr(numpy.floor(x_data), numpy.floor(size), prob)
+        size = numpy.round(size)
+        x_data = x_data-0.5
 
-    def _ppf(self, q_data, size, prob):
-        return numpy.ceil(special.bdtrik(q_data, numpy.floor(size), prob))
+        floor = numpy.zeros(x_data.shape)
+        indices = x_data >= 0
+        floor[indices] = special.bdtr(numpy.floor(x_data[indices]), size, prob)
+
+        ceil = numpy.ones(x_data.shape)
+        indices = x_data <= size
+        ceil[indices] = special.bdtr(numpy.ceil(x_data[indices]), size, prob)
+        ceil[numpy.isnan(ceil)] = 0  # left edge case
+
+        offset = x_data-numpy.floor(x_data)
+
+        return floor*(1-offset) + ceil*offset
+
+        offset = x_data-x_data_int+0.5
+        assert numpy.all(offset >= 0) and numpy.all(offset <= 1), (
+            "somethings up with the offset: %s" % offset)
+        x_data_int = numpy.clip(x_data_int, 0, size)
+        out = out_lower*(1-offset) + out_upper*offset
+        return out
 
     def _pdf(self, x_data, size, prob):
+        x_data = numpy.round(x_data)
         return special.comb(size, x_data)*prob**x_data*(1-prob)**(size-x_data)
 
     def _lower(self, size, prob):
-        return 0
+        return -0.5
 
     def _upper(self, size, prob):
-        return numpy.floor(size)+1
+        return numpy.round(size)+0.5
 
     def _mom(self, k_data, size, prob):
         x_data = numpy.arange(int(size)+1, dtype=int)

--- a/chaospy/distributions/collection/discrete_uniform.py
+++ b/chaospy/distributions/collection/discrete_uniform.py
@@ -21,10 +21,12 @@ class DiscreteUniform(Dist):
         >>> distribution
         DiscreteUniform(lower=2, upper=4)
         >>> q = numpy.linspace(0, 1, 9)
-        >>> distribution.inv(q)
-        array([2, 2, 2, 3, 3, 3, 4, 4, 4])
-        >>> distribution.fwd(distribution.inv(q)).round(4)
-        array([0. , 0. , 0. , 0.5, 0.5, 0.5, 1. , 1. , 1. ])
+        >>> q.round(2)
+        array([0.  , 0.12, 0.25, 0.38, 0.5 , 0.62, 0.75, 0.88, 1.  ])
+        >>> distribution.inv(q).round(2)
+        array([1.5 , 1.88, 2.25, 2.62, 3.  , 3.38, 3.75, 4.12, 4.5 ])
+        >>> distribution.fwd(distribution.inv(q)).round(2)
+        array([0.  , 0.12, 0.25, 0.38, 0.5 , 0.62, 0.75, 0.88, 1.  ])
         >>> distribution.pdf(distribution.inv(q)).round(4)
         array([0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0.5])
         >>> distribution.sample(4)
@@ -42,25 +44,28 @@ class DiscreteUniform(Dist):
 
     def _cdf(self, x_data, lower, upper):
         """Cumulative distribution function."""
-        return ((numpy.floor(x_data)-numpy.ceil(lower))/
-                (numpy.floor(upper)-numpy.ceil(lower)))
+        lower = numpy.round(lower)
+        upper = numpy.round(upper)
+        out = (x_data-lower+0.5)/(upper-lower+1)
+        return out
 
     def _lower(self, lower, upper):
         """Lower bounds."""
-        return numpy.ceil(lower)
+        return numpy.round(lower)-0.5
 
     def _upper(self, lower, upper):
         """Upper bounds."""
-        return numpy.floor(upper)
+        return numpy.round(upper)+0.5
 
     def _pdf(self, x_data, lower, upper):
         """Probability density function."""
-        return x_data**0/(numpy.floor(upper)-numpy.ceil(lower))
+        return x_data**0/(numpy.round(upper)-numpy.round(lower))
 
     def _ppf(self, q_data, lower, upper):
         """Point percentile function."""
-        return (numpy.floor(q_data*(
-            numpy.floor(upper+1)-numpy.ceil(lower))+numpy.ceil(lower)))
+        lower = numpy.round(lower)
+        upper = numpy.round(upper)
+        return q_data*(upper-lower+1)+lower-0.5
 
     def _mom(self, k_data, lower, upper):
         """Raw statistical moments."""

--- a/chaospy/distributions/evaluation/bound.py
+++ b/chaospy/distributions/evaluation/bound.py
@@ -52,9 +52,8 @@ def evaluate_lower(
     parameters = load_parameters(
         distribution, "_lower", parameters=parameters)
 
-    dtype = int if distribution.interpret_as_integer else float
     lower = distribution._lower(**parameters)
-    lower = numpy.asarray(lower, dtype=dtype)+numpy.zeros(len(distribution), dtype=dtype)
+    lower = numpy.asfarray(lower)+numpy.zeros(len(distribution))
 
     cache[distribution] = lower
     return lower
@@ -87,8 +86,7 @@ def evaluate_upper(
     parameters = load_parameters(
         distribution, "_upper", parameters=parameters)
 
-    dtype = int if distribution.interpret_as_integer else float
     upper = distribution._upper(**parameters)
-    upper = numpy.asarray(upper, dtype=dtype)+numpy.zeros(len(distribution), dtype=dtype)
+    upper = numpy.asfarray(upper)+numpy.zeros(len(distribution))
     cache[distribution] = upper
     return upper

--- a/chaospy/distributions/evaluation/inverse.py
+++ b/chaospy/distributions/evaluation/inverse.py
@@ -66,8 +66,7 @@ def evaluate_inverse(
         ``u_data`` using parameters ``parameters``.
     """
     cache = cache if cache is not None else {}
-    dtype = int if distribution.interpret_as_integer else float
-    out = numpy.zeros(u_data.shape, dtype=dtype)
+    out = numpy.zeros(u_data.shape)
 
     # Distribution self know how to handle inverse Rosenblatt.
     if hasattr(distribution, "_ppf"):

--- a/chaospy/quadrature/__init__.py
+++ b/chaospy/quadrature/__init__.py
@@ -68,6 +68,7 @@ from .sparse_grid import construct_sparse_grid
 from .combine import combine
 
 from .clenshaw_curtis import quad_clenshaw_curtis
+from .discrete import quad_discrete
 from .fejer import quad_fejer
 from .gaussian import quad_gaussian
 from .gauss_patterson import quad_gauss_patterson
@@ -76,6 +77,7 @@ from .gauss_lobatto import quad_gauss_lobatto
 from .gauss_kronrod import quad_gauss_kronrod
 from .gauss_radau import quad_gauss_radau
 from .genz_keister import quad_genz_keister
+from .grid import quad_grid
 from .leja import quad_leja
 from .newton_cotes import quad_newton_cotes
 

--- a/chaospy/quadrature/discrete.py
+++ b/chaospy/quadrature/discrete.py
@@ -42,6 +42,7 @@ def quad_discrete(order, domain=(0, 1)):
         order (int, numpy.ndarray):
             Quadrature order.
         domain (chaospy.distributions.baseclass.Dist, numpy.ndarray):
+            Either distribution or bounding of interval to integrate over.
 
     Returns:
         (numpy.ndarray, numpy.ndarray):

--- a/chaospy/quadrature/discrete.py
+++ b/chaospy/quadrature/discrete.py
@@ -1,0 +1,81 @@
+"""
+Generate the quadrature abscissas and weights for simple grid.
+
+Available to ensure that discrete distributions works along side
+continuous ones.
+
+Example usage
+-------------
+
+The first few orders with linear growth rule::
+
+    >>> distribution = chaospy.DiscreteUniform(-2, 2)
+    >>> for order in [0, 1, 2, 3, 4, 5, 9]:
+    ...     abscissas, weights = chaospy.generate_quadrature(
+    ...         order, distribution, rule="discrete")
+    ...     print(order, abscissas.round(3), weights.round(3))
+    0 [[0]] [1.]
+    1 [[-1  1]] [0.5 0.5]
+    2 [[-1  0  1]] [0.333 0.333 0.333]
+    3 [[-1  0  0  1]] [0.25 0.25 0.25 0.25]
+    4 [[-2  0  0  1  2]] [0.2 0.2 0.2 0.2 0.2]
+    5 [[-2  0  0  1  2]] [0.2 0.2 0.2 0.2 0.2]
+    9 [[-2  0  0  1  2]] [0.2 0.2 0.2 0.2 0.2]
+
+As the accuracy of discrete distribution plateau when all contained values are included, there is no reason to increase the number of nodes after this point.
+"""
+import numpy
+
+from .combine import combine_quadrature
+from .grid import quad_grid
+
+
+def quad_discrete(order, domain=(0, 1)):
+    """
+    Generate quadrature abscissas and weights for discrete distributions.
+
+    Same as regular grid, but `order` plateau at the `upper-lower-1`.
+    At this order, finite state discrete distributions are analytically
+    correct, and higher order will make the accuracy worsen.
+
+    Args:
+        order (int, numpy.ndarray):
+            Quadrature order.
+        domain (chaospy.distributions.baseclass.Dist, numpy.ndarray):
+
+    Returns:
+        (numpy.ndarray, numpy.ndarray):
+            The quadrature points and weights. The points are
+            equi-spaced grid on the interior of the domain bounds.
+            The weights are all equal to `1/len(weights[0])`.
+            Either distribution or bounding of interval to integrate over.
+
+    Examples:
+        >>> distribution = chaospy.DiscreteUniform(-2, 2)
+        >>> abscissas, weights = chaospy.quad_discrete(4, distribution)
+        >>> abscissas.round(4)
+        array([[-2., -1.,  0.,  1.,  2.]])
+        >>> weights.round(4)
+        array([0.2, 0.2, 0.2, 0.2, 0.2])
+        >>> abscissas, weights = chaospy.quad_discrete(9, distribution)
+        >>> abscissas.round(4)
+        array([[-2., -1.,  0.,  1.,  2.]])
+        >>> weights.round(4)
+        array([0.2, 0.2, 0.2, 0.2, 0.2])
+
+    """
+    from ..distributions.baseclass import Dist
+    if isinstance(domain, Dist):
+        abscissas, weights = quad_discrete(order, (domain.lower, domain.upper))
+        weights *= domain.pdf(abscissas).flatten()
+        weights /= numpy.sum(weights)
+        return abscissas, weights
+
+    order = numpy.atleast_1d(order)
+    order, lower, upper = numpy.broadcast_arrays(order, domain[0], domain[1])
+    assert order.ndim == 1, "too many dimensions"
+
+    order_max = numpy.round(upper-lower).astype(int)-1
+    order = numpy.where(order > order_max, order_max, order)
+
+    return quad_grid(order, (lower, upper))

--- a/chaospy/quadrature/frontend.py
+++ b/chaospy/quadrature/frontend.py
@@ -40,6 +40,7 @@ import numpy
 from .combine import combine
 
 from .clenshaw_curtis import quad_clenshaw_curtis
+from .discrete import quad_discrete
 from .fejer import quad_fejer
 from .gaussian import quad_gaussian
 from .gauss_patterson import quad_gauss_patterson
@@ -48,6 +49,7 @@ from .gauss_lobatto import quad_gauss_lobatto
 from .gauss_kronrod import quad_gauss_kronrod
 from .gauss_radau import quad_gauss_radau
 from .genz_keister import quad_genz_keister
+from .grid import quad_grid
 from .leja import quad_leja
 from .newton_cotes import quad_newton_cotes
 
@@ -63,6 +65,8 @@ QUAD_NAMES = {
     "z": "genz_keister", "genz_keister": "genz_keister",
     "j": "leja", "leja": "leja",
     "n": "newton_cotes", "newton_cotes": "newton_cotes",
+    "d": "discrete", "discrete": "discrete",
+    "i": "grid", "grid": "grid",
 }
 QUAD_FUNCTIONS = {
     "clenshaw_curtis": quad_clenshaw_curtis,
@@ -76,6 +80,8 @@ QUAD_FUNCTIONS = {
     "genz_keister": quad_genz_keister,
     "leja": quad_leja,
     "newton_cotes": quad_newton_cotes,
+    "discrete": quad_discrete,
+    "grid": quad_grid,
 }
 
 

--- a/chaospy/quadrature/frontend.py
+++ b/chaospy/quadrature/frontend.py
@@ -172,7 +172,7 @@ def generate_quadrature(
     rule = QUAD_NAMES[rule.lower()]
     kwargs = {}
 
-    if rule in ("clenshaw_curtis", "fejer", "newton_cotes"):
+    if rule in ("clenshaw_curtis", "fejer", "newton_cotes", "discrete"):
         kwargs.update(growth=growth, segments=segments)
 
     if rule in ("gaussian", "gauss_kronrod", "gauss_radau", "gauss_lobatto"):
@@ -188,7 +188,7 @@ def generate_quadrature(
     from ..distributions.operators.joint import J
     from ..distributions.evaluation import sorted_dependencies
     if dist.interpret_as_integer:
-        abscissas = abscissas.astype(int)
+        abscissas = numpy.around(abscissas).astype(int)
     elif isinstance(dist, J):
         for dist_ in sorted_dependencies(dist):
             if dist_ in dist.inverse_map and dist_.interpret_as_integer:

--- a/chaospy/quadrature/frontend.py
+++ b/chaospy/quadrature/frontend.py
@@ -162,7 +162,7 @@ def generate_quadrature(
     if not isinstance(rule, str):
         order = numpy.ones(len(dist), dtype=int)*order
         abscissas, weights = zip(*[
-            generate_quadrature(order_, dist_, rule_, growth)
+            generate_quadrature(order_, dist_, rule_, growth=growth)
             for order_, dist_, rule_ in zip(order, dist, rule)
         ])
         abscissas = combine([abscissa.T for abscissa in abscissas]).T

--- a/chaospy/quadrature/grid.py
+++ b/chaospy/quadrature/grid.py
@@ -1,0 +1,56 @@
+"""
+Generate the quadrature abscissas and weights for simple grid.
+
+Mostly available to ensure that discrete distributions works along side
+continuous ones.
+"""
+import numpy
+
+from .combine import combine_quadrature
+
+
+def quad_grid(order, domain=(0, 1)):
+    """
+    Generate the quadrature abscissas and weights for simple grid.
+
+    Args:
+        order (int, numpy.ndarray):
+            Quadrature order.
+        domain (chaospy.distributions.baseclass.Dist, numpy.ndarray):
+            Either distribution or bounding of interval to integrate over.
+
+    Returns:
+        (numpy.ndarray, numpy.ndarray):
+            The quadrature points and weights. The points are
+            equi-spaced grid on the interior of the domain bounds.
+            The weights are all equal to `1/len(weights[0])`.
+
+    Example:
+        >>> abscissas, weights = chaospy.quad_grid(4, chaospy.Uniform(-1, 1))
+        >>> abscissas.round(4)
+        array([[-0.8, -0.4,  0. ,  0.4,  0.8]])
+        >>> weights.round(4)
+        array([0.2, 0.2, 0.2, 0.2, 0.2])
+        >>> abscissas, weights = chaospy.quad_grid([1, 1])
+        >>> abscissas.round(4)
+        array([[0.25, 0.25, 0.75, 0.75],
+               [0.25, 0.75, 0.25, 0.75]])
+        >>> weights.round(4)
+        array([0.25, 0.25, 0.25, 0.25])
+
+    """
+    from ..distributions.baseclass import Dist
+    if isinstance(domain, Dist):
+        abscissas, weights = quad_grid(order, (domain.lower, domain.upper))
+        weights *= domain.pdf(abscissas).flatten()
+        weights /= numpy.sum(weights)
+        return abscissas, weights
+
+    order = numpy.atleast_1d(order)
+    order, lower, upper = numpy.broadcast_arrays(order, domain[0], domain[1])
+    assert order.ndim == 1, "too many dimensions"
+    abscissas = tuple(numpy.linspace(0, 1, 2*order_+3)[1::2] for order_ in order)
+    weights = tuple(numpy.repeat(1./(order_+1), order_+1) for order_ in order)
+
+    abscissas_, weights_ = combine_quadrature(abscissas, weights, (lower, upper))
+    return abscissas_, weights_

--- a/chaospy/quadrature/newton_cotes.py
+++ b/chaospy/quadrature/newton_cotes.py
@@ -98,7 +98,7 @@ def quad_newton_cotes(order, domain=(0, 1), growth=False, segments=1):
     from ..distributions.baseclass import Dist
     if isinstance(domain, Dist):
         abscissas, weights = quad_newton_cotes(
-            order, (domain.lower, domain.upper), growth)
+            order, (domain.lower, domain.upper), growth, segments)
         weights *= domain.pdf(abscissas).flatten()
         weights /= numpy.sum(weights)
         return abscissas, weights

--- a/chaospy/quadrature/sparse_grid.py
+++ b/chaospy/quadrature/sparse_grid.py
@@ -59,6 +59,7 @@ from itertools import product
 import numpy
 from scipy.special import comb
 import numpoly
+import chaospy
 
 
 def construct_sparse_grid(
@@ -116,6 +117,10 @@ def construct_sparse_grid(
         array([ 0.17,  0.25, -0.5 ,  0.25,  0.67,  0.25, -0.5 ,  0.25,  0.17])
     """
     orders = order*numpy.ones(len(dist), dtype=int)
+
+    assert isinstance(dist, chaospy.Dist), "dist must be chaospy.Dist"
+    if not isinstance(dist, chaospy.J):
+        dist = chaospy.J(dist)
 
     if isinstance(rule, str):
         rule = (rule,)*len(dist)

--- a/docs/quadrature.rst
+++ b/docs/quadrature.rst
@@ -30,6 +30,14 @@ Clenshaw-Curtis Quadrature
 .. automodule:: chaospy.quadrature.clenshaw_curtis
 .. autofunction:: chaospy.quadrature.clenshaw_curtis.quad_clenshaw_curtis
 
+.. _discrete:
+
+Discrete Quadrature
+-------------------
+
+.. automodule:: chaospy.quadrature.discrete
+.. autofunction:: chaospy.quadrature.discrete.quad_discrete
+
 .. _fejer:
 
 Fejér Quadrature


### PR DESCRIPTION
Something on the backburner a while, which I finally got around to with #258.

Discrete distributions:
* Intepret discrete distributions (DiscreteUniform and Binomial for now) as a semi-continous distribution, meaning that instead of accepting integers as input, a margin +/-0.5 is accepted. E.g. Binomial(3, 0.5) acceps [-0.5, 0.5) as 0, [0.5, 1.5) as 1, etc.
* The interface remains mostly the same except for forward/inverse mapping `dist.fwd/dist.inv` is turned into continous mappings. This changes the behavior of the mapping a bit as they now strecthes out.
* distribution functions `dist.pdf`, `dist.cdf` and `dist.sample` are constructed to work as befpre. 

New quadrature rules:
* quad_grid / quad_discrete added, designed to work well with discrete distributions.
* Default change in `chaospy.generate_quadrature`: Use `discrete` for discrete distributions, and `clenshaw_curtis` for continuous ones (like before).