### PR TITLE
Refactoring the cache system.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,21 @@
 Master Branch
 =============
 
+Version 4.0.3 (2020-09-17)
+==========================
+
+ADDED:
+  * New baseclass `Conditional` representing slices of multivariate
+    distributions.
+  * Support for `ConditionalMeanCovariance` moments given no conditional.
+CHANGED:
+  * Backend interface `_get_value` replaced with `_get_cache_1` and
+    `_get_cache_2`. For former is new, the latter is a renaming.
+  * Cache content changed from `Dict[Distribution, ndarray]` to
+    `Dict[Distribution, Tuple[ndarray, ndarray]]` to store both inputs and
+    outputs for each calculations.
+  * backend function `_value` replaced with `_cache` for consistency.
+
 Version 4.0.2 (2020-09-17)
 ==========================
 

--- a/chaospy/distributions/baseclass/__init__.py
+++ b/chaospy/distributions/baseclass/__init__.py
@@ -1,4 +1,5 @@
 from .distribution import Distribution
+from .conditional import Conditional
 from .core import DistributionCore
 from .copula import Copula
 

--- a/chaospy/distributions/baseclass/conditional.py
+++ b/chaospy/distributions/baseclass/conditional.py
@@ -1,0 +1,14 @@
+"""Baseclass for all conditional distributions."""
+import numpy
+from .distribution import Distribution
+
+
+class Conditional(Distribution):
+    """Conditional distribution baseclass."""
+
+    def get_parameters(self, cache):
+        """Get distribution parameters."""
+        parameters = super(Conditional, self).get_parameters(cache)
+        if "conditions" not in parameters:
+            parameters["conditions"] = []
+        return parameters

--- a/chaospy/distributions/baseclass/copula.py
+++ b/chaospy/distributions/baseclass/copula.py
@@ -101,5 +101,5 @@ class Copula(Distribution):
         raise chaospy.UnsupportedFeature(
             "Joint distribution with dependencies not supported.")
 
-    def _value(self, dist, trans, cache):
+    def _cache(self, dist, trans, cache):
         return self

--- a/chaospy/distributions/baseclass/core.py
+++ b/chaospy/distributions/baseclass/core.py
@@ -110,8 +110,7 @@ class DistributionCore(Distribution):
         parameters.pop("cache")
         for key, value in parameters.items():
             if isinstance(value, Distribution):
-                if value in cache:
-                    parameters[key] = cache[value]
+                parameters[key] = value._get_cache_1(cache)
         return parameters
 
     def _check_parameters(self, parameters):
@@ -149,5 +148,5 @@ class DistributionCore(Distribution):
         raise chaospy.UnsupportedFeature(
             "%s: does not support analytical recurrence coefficients." % self)
 
-    def _value(self, **kwargs):
+    def _cache(self, **kwargs):
         return self

--- a/chaospy/distributions/baseclass/joint.py
+++ b/chaospy/distributions/baseclass/joint.py
@@ -380,8 +380,10 @@ class J(Distribution):
             return J(*[parameters["_%03d" % idx] for idx in i])
         raise IndexError("index not recognised")
 
-    def _value(self, cache, **kwargs):
-        values = [kwargs[key]._get_value(cache) for key in sorted(kwargs)]
+    def _cache(self, cache, **kwargs):
+        indices = sorted(kwargs)
+        keys = [kwargs[idx]._get_cache_1(cache) for idx in indices]
+        values = [kwargs[idx]._get_cache_2(cache) for idx in indices]
         if not any([isinstance(value, Distribution) for value in values]):
-            return numpy.vstack(values)
+            return numpy.vstack(keys), numpy.vstack(values)
         return self

--- a/chaospy/distributions/baseclass/lower_upper.py
+++ b/chaospy/distributions/baseclass/lower_upper.py
@@ -120,5 +120,5 @@ class LowerUpper(DistributionCore):
         coeff1 = coeff1*scale*scale
         return coeff0, coeff1
 
-    def _value(self, **kwargs):
+    def _cache(self, **kwargs):
         return self

--- a/chaospy/distributions/collection/mv_log_normal.py
+++ b/chaospy/distributions/collection/mv_log_normal.py
@@ -85,5 +85,5 @@ class MvLogNormal(Distribution):
     def _upper(self, loc, C, Ci, scale, cache):
         return numpy.exp(7.1*numpy.sqrt(numpy.diag(scale)) + loc.T).T
 
-    def _value(self, loc, C, Ci, scale, cache):
+    def _cache(self, loc, C, Ci, scale, cache):
         return self

--- a/chaospy/distributions/collection/mv_normal.py
+++ b/chaospy/distributions/collection/mv_normal.py
@@ -2,6 +2,7 @@
 import logging
 import numpy
 from scipy import special
+import chaospy
 
 from .normal import normal
 from ..baseclass import MeanCovariance
@@ -73,6 +74,11 @@ class MvNormal(MeanCovariance):
         )
 
     def _mom(self, k, mean, covariance, cache):
+        if isinstance(mean, chaospy.Distribution):
+            mean = mean._get_cache_1(cache)
+            if isinstance(mean, chaospy.Distribution):
+                raise chaospy.UnsupportedFeature(
+                    "Analytical moment of a conditional not supported")
         out = 0.
         for idx, kdx in enumerate(numpy.ndindex(*[_+1 for _ in k])):
             coef = numpy.prod(special.comb(k.T, kdx).T, 0)

--- a/chaospy/distributions/copulas/archimedean.py
+++ b/chaospy/distributions/copulas/archimedean.py
@@ -114,5 +114,5 @@ class Archimedean(Distribution):
         out = out*u_loc**(-1/theta-order)
         return out
 
-    def _value(self, dist, trans, cache):
+    def _cache(self, dist, trans, cache):
         return self

--- a/chaospy/distributions/copulas/nataf.py
+++ b/chaospy/distributions/copulas/nataf.py
@@ -45,7 +45,7 @@ class nataf(Distribution):
     def _upper(self, C, Ci, cache):
         return numpy.ones(len(self))
 
-    def _value(self, C, Ci, cache):
+    def _cache(self, C, Ci, cache):
         return self
 
 

--- a/chaospy/distributions/copulas/t_copula.py
+++ b/chaospy/distributions/copulas/t_copula.py
@@ -44,7 +44,7 @@ class t_copula(Distribution):
     def _upper(self, df, C, Ci, cache):
         return numpy.ones(len(self))
 
-    def _value(self, df, C, Ci, cache):
+    def _cache(self, df, C, Ci, cache):
         return self
 
 

--- a/chaospy/distributions/operators/addition.py
+++ b/chaospy/distributions/operators/addition.py
@@ -228,7 +228,7 @@ class Add(OperatorDistribution):
         coeff0, coeff1 = left._get_ttr(kloc)
         return coeff0+numpy.asarray(right), coeff1
 
-    def _value(self, left, right, cache):
+    def _cache(self, left, right, cache):
         del cache
         if isinstance(left, Distribution) or isinstance(right, Distribution):
             return self

--- a/chaospy/distributions/operators/logarithm.py
+++ b/chaospy/distributions/operators/logarithm.py
@@ -66,7 +66,7 @@ class Logn(OperatorDistribution):
     def _ttr(self, kloc, left, right, cache):
         raise chaospy.UnsupportedFeature("%s: Analytical TTR for logarithm not supported", self)
 
-    def _value(self, left, right, cache):
+    def _cache(self, left, right, cache):
         if isinstance(left, Distribution):
             return self
         return numpy.log(left)/numpy.log(right.item(0))

--- a/chaospy/distributions/operators/multiply.py
+++ b/chaospy/distributions/operators/multiply.py
@@ -299,7 +299,7 @@ class Mul(OperatorDistribution):
         coeff0, coeff1 = left._get_ttr(kloc)
         return coeff0*right, coeff1*right*right
 
-    def _value(self, left, right, cache):
+    def _cache(self, left, right, cache):
         if isinstance(left, Distribution) or isinstance(right, Distribution):
             return self
         return left*right

--- a/chaospy/distributions/operators/negative.py
+++ b/chaospy/distributions/operators/negative.py
@@ -78,7 +78,7 @@ class Neg(OperatorDistribution):
         alpha, beta = left._get_ttr(kloc)
         return -alpha, beta
 
-    def _value(self, left, right, cache):
+    def _cache(self, left, right, cache):
         del right
         del cache
         if isinstance(left, Distribution):

--- a/chaospy/distributions/operators/operator.py
+++ b/chaospy/distributions/operators/operator.py
@@ -52,7 +52,7 @@ class OperatorDistribution(Distribution):
         parameters = super(OperatorDistribution, self).get_parameters(**kwargs)
         assert set(parameters) == {"cache", "left", "right"}
         if isinstance(parameters["left"], Distribution):
-            parameters["left"] = parameters["left"]._get_value(cache=parameters["cache"])
+            parameters["left"] = parameters["left"]._get_cache_1(cache=parameters["cache"])
         if isinstance(parameters["right"], Distribution):
-            parameters["right"] = parameters["right"]._get_value(cache=parameters["cache"])
+            parameters["right"] = parameters["right"]._get_cache_1(cache=parameters["cache"])
         return parameters

--- a/chaospy/distributions/operators/power.py
+++ b/chaospy/distributions/operators/power.py
@@ -237,7 +237,7 @@ class Pow(OperatorDistribution):
                 "distribution to fractional power not supported.")
         return left._get_mom(k*right)
 
-    def _value(self, left, right, cache):
+    def _cache(self, left, right, cache):
         if isinstance(left, Distribution) or isinstance(right, Distribution):
             return self
         return left**right

--- a/chaospy/distributions/operators/trunkation.py
+++ b/chaospy/distributions/operators/trunkation.py
@@ -104,9 +104,9 @@ class Trunc(Distribution):
             [0.  0.  0.5 1. ]
         """
         if isinstance(left, Distribution):
-            left = left._get_value(cache)
+            left = left._get_cache_1(cache)
         if isinstance(right, Distribution):
-            right = right._get_value(cache)
+            right = right._get_cache_1(cache)
         if isinstance(left, Distribution):
             right = (numpy.array(right).T*numpy.ones(xloc.shape).T).T
             uloc1 = left._get_fwd(right, cache=cache.copy())
@@ -138,9 +138,9 @@ class Trunc(Distribution):
             [0.  0.  0.  2.5 0. ]
         """
         if isinstance(left, Distribution):
-            left = left._get_value(cache)
+            left = left._get_cache_1(cache)
         if isinstance(right, Distribution):
-            right = right._get_value(cache)
+            right = right._get_cache_1(cache)
         if isinstance(left, Distribution):
             right = (numpy.array(right).T*numpy.ones(xloc.shape).T).T
             uloc1 = left._get_fwd(right, cache=cache.copy())
@@ -166,9 +166,9 @@ class Trunc(Distribution):
             [0.64 0.68 0.96]
         """
         if isinstance(left, Distribution):
-            left = left._get_value(cache)
+            left = left._get_cache_1(cache)
         if isinstance(right, Distribution):
-            right = right._get_value(cache)
+            right = right._get_cache_1(cache)
         if isinstance(left, Distribution):
             right = (numpy.array(right).T*numpy.ones(q.shape).T).T
             uloc = left._get_fwd(right, cache=cache.copy())
@@ -179,7 +179,7 @@ class Trunc(Distribution):
             out = right._get_inv(q*(1-uloc)+uloc, cache=cache)
         return out
 
-    def _value(self, **kwargs):
+    def _cache(self, **kwargs):
         raise chaospy.UnsupportedFeature(
             "%s: does not support value retrieval." % self)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "chaospy"
-version = "4.0.2"
+version = "4.0.3"
 description = "Numerical tool for perfroming uncertainty quantification"
 license = "MIT"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
When dealing with inverse Rosenblatt transformation, one often needs the
input values from the previous iterations. While normally only the
output values are stored in the cache.

This refactor changes the cache system to account for both forward and
inverse values.