### PR TITLE
Two-sided truncation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,9 @@
 Master Branch
 =============
 
+CHANGED:
+  * `chaospy.Trunc` updated to take both `lower` and `upper` at the same time.
+
 Version 4.0-beta3 (2020-10-22)
 ==============================
 

--- a/chaospy/distributions/baseclass/utils.py
+++ b/chaospy/distributions/baseclass/utils.py
@@ -232,7 +232,9 @@ def format_repr_kwargs(**parameters):
     defaults_only = True
     for name, (param, default) in list(parameters.items()):
         defaults_only &= (
-            isinstance(param, (int, float)) and param == default)
+            (isinstance(param, (int, float)) and param == default) or
+            (param is default is None)
+        )
         if isinstance(param, numpy.ndarray):
             parameters[name] = (param.tolist(), default)
     if defaults_only:

--- a/chaospy/distributions/operators/truncation.py
+++ b/chaospy/distributions/operators/truncation.py
@@ -10,19 +10,19 @@ Simple distribution to start with::
     >>> distribution.inv([0.9, 0.99, 0.999]).round(4)
     array([1.2816, 2.3263, 3.0902])
 
-Same distribution, but with a right-side truncation::
+Same distribution, but with a upper truncation::
 
-    >>> right_trunc = chaospy.Trunc(chaospy.Normal(0, 1), 1)
+    >>> right_trunc = chaospy.Trunc(chaospy.Normal(0, 1), upper=1)
     >>> right_trunc
-    Trunc(Normal(mu=0, sigma=1), 1)
+    Trunc(Normal(mu=0, sigma=1), upper=1)
     >>> right_trunc.inv([0.9, 0.99, 0.999]).round(4)
     array([0.6974, 0.9658, 0.9965])
 
-Same, but with left-side truncation::
+Same, but with lower truncation::
 
-    >>> left_trunc = chaospy.Trunc(1, chaospy.Normal(0, 1))
+    >>> left_trunc = chaospy.Trunc(chaospy.Normal(0, 1), lower=1)
     >>> left_trunc
-    Trunc(1, Normal(mu=0, sigma=1))
+    Trunc(Normal(mu=0, sigma=1), lower=1)
     >>> left_trunc.inv([0.001, 0.01, 0.1]).round(4)
     array([1.0007, 1.0066, 1.0679])
 
@@ -33,153 +33,174 @@ import chaospy
 from ..baseclass import Distribution, OperatorDistribution
 
 
-class Trunc(OperatorDistribution):
+class Trunc(Distribution):
     """Truncation."""
 
-    def __init__(self, left, right):
+    def __init__(self, dist, lower=None, upper=None):
         """
         Constructor.
 
         Args:
-            left (Distribution, numpy.ndarray):
-                Left hand side.
-            right (Distribution, numpy.ndarray):
-                Right hand side.
+            dist (Distribution):
+                Distribution to be truncated.
+            lower (Distribution, numpy.ndarray):
+                Lower truncation bound.
+            upper (Distribution, numpy.ndarray):
+                Upper truncation bound.
         """
-        repr_args = [left, right]
-        exclusion = None
-        if isinstance(left, Distribution):
-            if left.stochastic_dependent:
+        assert isinstance(dist, Distribution)
+        repr_args = [dist]
+        repr_args += chaospy.format_repr_kwargs(lower=(lower, None))
+        repr_args += chaospy.format_repr_kwargs(upper=(upper, None))
+        exclusion = set()
+        for deps in dist._dependencies:
+            exclusion.update(deps)
+        if isinstance(lower, Distribution):
+            if lower.stochastic_dependent:
                 raise chaospy.StochasticallyDependentError(
                     "Joint distribution with dependencies not supported.")
+            assert len(dist) == len(lower)
+        elif lower is None:
+            lower = dist.lower
         else:
-            left = numpy.atleast_1d(left)
-        if isinstance(right, Distribution):
-            if right.stochastic_dependent:
+            lower = numpy.atleast_1d(lower)
+        if isinstance(upper, Distribution):
+            if upper.stochastic_dependent:
                 raise chaospy.StochasticallyDependentError(
                     "Joint distribution with dependencies not supported.")
+            assert len(dist) == len(upper)
+        elif upper is None:
+            upper = dist.upper
         else:
-            right = numpy.atleast_1d(right)
+            upper = numpy.atleast_1d(upper)
+
+        dependencies, parameters, rotation = chaospy.declare_dependencies(
+            distribution=self,
+            parameters=dict(lower=lower, upper=upper),
+            length=len(dist),
+        )
         super(Trunc, self).__init__(
-            left=left,
-            right=right,
+            parameters=parameters,
+            dependencies=dependencies,
+            exclusion=exclusion,
             repr_args=repr_args,
         )
+        self._dist = dist
 
-    def _lower(self, idx, left, right, cache):
+    def get_parameters(self, idx, cache, assert_numerical=True):
+        parameters = super(Trunc, self).get_parameters(
+            idx, cache, assert_numerical=assert_numerical)
+        assert set(parameters) == {"cache", "lower", "upper", "idx"}
+
+        if isinstance(parameters["lower"], Distribution):
+            parameters["lower"] = parameters["lower"]._get_cache(idx, cache=parameters["cache"], get=0)
+        elif len(parameters["lower"]) > 1 and idx is not None:
+            parameters["lower"] = parameters["lower"][idx]
+        if isinstance(parameters["upper"], Distribution):
+            parameters["upper"] = parameters["upper"]._get_cache(idx, cache=parameters["cache"], get=0)
+        elif len(parameters["upper"]) > 1 and idx is not None:
+            parameters["upper"] = parameters["upper"][idx]
+        if assert_numerical:
+            assert (not isinstance(parameters["lower"], Distribution) or
+                    not isinstance(parameters["upper"], Distribution))
+        if idx is None:
+            del parameters["idx"]
+        return parameters
+
+    def _lower(self, idx, lower, upper, cache):
         """
         Distribution lower bound.
 
         Examples:
-            >>> chaospy.Trunc(chaospy.Uniform(), 0.6).lower
+            >>> chaospy.Trunc(chaospy.Uniform(), upper=0.6).lower
             array([0.])
-            >>> chaospy.Trunc(0.6, chaospy.Uniform()).lower
+            >>> chaospy.Trunc(chaospy.Uniform(), lower=0.6).lower
             array([0.6])
         """
-        del right
-        if isinstance(left, Distribution):
-            left = left._get_lower(idx, cache=cache)
-        return left
+        del upper
+        if isinstance(lower, Distribution):
+            lower = lower._get_lower(idx, cache=cache)
+        return lower
 
-    def _upper(self, idx, left, right, cache):
+    def _upper(self, idx, lower, upper, cache):
         """
         Distribution lower bound.
 
         Examples:
-            >>> chaospy.Trunc(chaospy.Uniform(), 0.6).upper
+            >>> chaospy.Trunc(chaospy.Uniform(), upper=0.6).upper
             array([0.6])
-            >>> chaospy.Trunc(0.6, chaospy.Uniform()).upper
+            >>> chaospy.Trunc(chaospy.Uniform(), lower=0.6).upper
             array([1.])
         """
-        del left
-        if isinstance(right, Distribution):
-            right = right._get_upper(idx, cache=cache)
-        return right
+        del lower
+        if isinstance(upper, Distribution):
+            upper = upper._get_upper(idx, cache=cache)
+        return upper
 
-    def _cdf(self, xloc, idx, left, right, cache):
+    def _cdf(self, xloc, idx, lower, upper, cache):
         """
         Cumulative distribution function.
 
         Example:
             >>> chaospy.Uniform().fwd([-0.5, 0.3, 0.7, 1.2])
             array([0. , 0.3, 0.7, 1. ])
-            >>> chaospy.Trunc(chaospy.Uniform(), 0.4).fwd([-0.5, 0.2, 0.8, 1.2])
+            >>> chaospy.Trunc(chaospy.Uniform(), upper=0.4).fwd([-0.5, 0.2, 0.8, 1.2])
             array([0. , 0.5, 1. , 1. ])
-            >>> chaospy.Trunc(0.6, chaospy.Uniform()).fwd([-0.5, 0.2, 0.8, 1.2])
+            >>> chaospy.Trunc(chaospy.Uniform(), lower=0.6).fwd([-0.5, 0.2, 0.8, 1.2])
             array([0. , 0. , 0.5, 1. ])
         """
-        if isinstance(left, Distribution):
-            left = left._get_cache(idx, cache, get=0)
-        if isinstance(right, Distribution):
-            right = right._get_cache(idx, cache, get=0)
-        if isinstance(left, Distribution):
-            right = (numpy.array(right).T*numpy.ones(xloc.shape).T).T
-            uloc1 = left._get_fwd(right, idx, cache=cache.copy())
-            uloc2 = left._get_fwd(xloc, idx, cache=cache)
-            out = uloc2/uloc1
-        else:
-            left = (numpy.array(left).T*numpy.ones(xloc.shape).T).T
-            uloc1 = right._get_fwd(left, idx, cache=cache.copy())
-            uloc2 = right._get_fwd(xloc, idx, cache=cache)
-            out = (uloc2-uloc1)/(1-uloc1)
-        return out
+        assert not isinstance(lower, Distribution)
+        assert not isinstance(upper, Distribution)
+        lower = numpy.broadcast_to(lower, xloc.shape)
+        upper = numpy.broadcast_to(upper, xloc.shape)
+        lower = self._dist._get_fwd(lower, idx, cache=cache.copy())
+        upper = self._dist._get_fwd(upper, idx, cache=cache.copy())
+        uloc = self._dist._get_fwd(xloc, idx, cache)
+        return (uloc-lower)/(1-lower)/upper
 
-    def _pdf(self, xloc, idx, left, right, cache):
+    def _pdf(self, xloc, idx, lower, upper, cache):
         """
         Probability density function.
 
         Example:
-            >>> dist = chaospy.Trunc(chaospy.Uniform(), 0.6)
+            >>> dist = chaospy.Trunc(chaospy.Uniform(), upper=0.6)
             >>> dist.pdf([-0.25, 0.25, 0.5, 0.75, 1.25])
             array([0.        , 1.66666667, 1.66666667, 0.        , 0.        ])
-            >>> dist = chaospy.Trunc(chaospy.Uniform(), 0.4)
+            >>> dist = chaospy.Trunc(chaospy.Uniform(), upper=0.4)
             >>> dist.pdf([-0.25, 0.25, 0.5, 0.75, 1.25])
             array([0. , 2.5, 0. , 0. , 0. ])
-            >>> dist = chaospy.Trunc(0.4, chaospy.Uniform())
+            >>> dist = chaospy.Trunc(chaospy.Uniform(), lower=0.4)
             >>> dist.pdf([-0.25, 0.25, 0.5, 0.75, 1.25])
             array([0.        , 0.        , 1.66666667, 1.66666667, 0.        ])
-            >>> dist = chaospy.Trunc(0.6, chaospy.Uniform())
+            >>> dist = chaospy.Trunc(chaospy.Uniform(), lower=0.6)
             >>> dist.pdf([-0.25, 0.25, 0.5, 0.75, 1.25])
             array([0. , 0. , 0. , 2.5, 0. ])
         """
-        if isinstance(left, Distribution):
-            left = left._get_cache(idx, cache, get=0)
-        if isinstance(right, Distribution):
-            right = right._get_cache(idx, cache, get=0)
-        if isinstance(left, Distribution):
-            right = (numpy.array(right).T*numpy.ones(xloc.shape).T).T
-            uloc1 = left._get_fwd(right, idx,  cache=cache.copy())
-            uloc2 = left._get_pdf(xloc, idx, cache=cache)
-            out = uloc2/uloc1
-        else:
-            left = (numpy.array(left).T*numpy.ones(xloc.shape).T).T
-            uloc1 = right._get_fwd(left, idx, cache=cache.copy())
-            uloc2 = right._get_pdf(xloc, idx, cache=cache)
-            out = uloc2/(1-uloc1)
-        return out
+        assert not isinstance(lower, Distribution)
+        assert not isinstance(upper, Distribution)
+        lower = numpy.broadcast_to(lower, xloc.shape)
+        upper = numpy.broadcast_to(upper, xloc.shape)
+        lower = self._dist._get_fwd(lower, idx, cache=cache.copy())
+        upper = self._dist._get_fwd(upper, idx, cache=cache.copy())
+        uloc = self._dist._get_pdf(xloc, idx, cache=cache)
+        return uloc/(1-lower)/upper
 
-    def _ppf(self, q, idx, left, right, cache):
+    def _ppf(self, qloc, idx, lower, upper, cache):
         """
         Point percentile function.
 
         Example:
             >>> chaospy.Uniform().inv([0.1, 0.2, 0.9])
             array([0.1, 0.2, 0.9])
-            >>> chaospy.Trunc(chaospy.Uniform(), 0.4).inv([0.1, 0.2, 0.9])
+            >>> chaospy.Trunc(chaospy.Uniform(), upper=0.4).inv([0.1, 0.2, 0.9])
             array([0.04, 0.08, 0.36])
-            >>> chaospy.Trunc(0.6, chaospy.Uniform()).inv([0.1, 0.2, 0.9])
+            >>> chaospy.Trunc(chaospy.Uniform(), lower=0.6).inv([0.1, 0.2, 0.9])
             array([0.64, 0.68, 0.96])
         """
-        if isinstance(left, Distribution):
-            left = left._get_cache(idx, cache, get=0)
-        if isinstance(right, Distribution):
-            right = right._get_cache(idx, cache, get=0)
-        if isinstance(left, Distribution):
-            right = (numpy.array(right).T*numpy.ones(q.shape).T).T
-            uloc = left._get_fwd(right, idx, cache=cache.copy())
-            out = left._get_inv(q*uloc, idx, cache=cache)
-        else:
-            left = (numpy.array(left).T*numpy.ones(q.shape).T).T
-            uloc = right._get_fwd(left, idx, cache=cache.copy())
-            out = right._get_inv(q*(1-uloc)+uloc, idx, cache=cache)
-        return out
+        assert not isinstance(lower, Distribution)
+        assert not isinstance(upper, Distribution)
+        lower = numpy.broadcast_to(lower, qloc.shape)
+        upper = numpy.broadcast_to(upper, qloc.shape)
+        lower = self._dist._get_fwd(lower, idx, cache=cache.copy())
+        upper = self._dist._get_fwd(upper, idx, cache=cache.copy())
+        return self._dist._get_inv(qloc*upper*(1-lower)+lower, idx, cache=cache)

--- a/docs/distributions/collection.rst
+++ b/docs/distributions/collection.rst
@@ -9,12 +9,14 @@ List of Distributions
 
     .. code-block::
 
-        >>> upper_trunc = chaospy.Trunc(chaospy.Weibull(1), 2)
-        >>> print(upper_trunc)
-        Trunc(Weibull(1), 2)
-        >>> upper_and_lower_trunc = chaospy.Trunc(0.5, upper_trunc)
-        >>> print(upper_and_lower_trunc)
-        Trunc(0.5, Trunc(Weibull(1), 2))
+        >>> distribution = chaospy.Weibull(1)
+        >>> upper_trunc = chaospy.Trunc(distribution, upper=2)
+        >>> upper_trunc
+        Trunc(Weibull(1), upper=2)
+        >>> upper_and_lower_trunc = chaospy.Trunc(
+        ...     distribution, lower=0.5, upper=2)
+        >>> upper_and_lower_trunc
+        Trunc(Weibull(1), lower=0.5, upper=2)
 
 Alpha Distribution
 ------------------

--- a/tests/distributions/operators/test_addition.py
+++ b/tests/distributions/operators/test_addition.py
@@ -1,3 +1,4 @@
+"""Tests for the addition operator."""
 from pytest import raises
 
 import numpy

--- a/tests/distributions/operators/test_multiply.py
+++ b/tests/distributions/operators/test_multiply.py
@@ -1,3 +1,4 @@
+"""Tests for the multiplication operator."""
 from pytest import raises
 import numpy
 

--- a/tests/distributions/operators/test_operators.py
+++ b/tests/distributions/operators/test_operators.py
@@ -1,3 +1,4 @@
+"""Tests for the various base-operators."""
 import numpy
 import chaospy
 

--- a/tests/distributions/operators/test_truncation.py
+++ b/tests/distributions/operators/test_truncation.py
@@ -1,0 +1,57 @@
+"""Tests for truncation operator."""
+import numpy
+import chaospy
+
+
+def test_truncation_lower_as_dist():
+    """Ensure lower bound as a distribution is supported."""
+    dist1 = chaospy.Normal()
+    dist2 = chaospy.Trunc(chaospy.Normal(), lower=dist1)
+    joint = chaospy.J(dist1, dist2)
+    ref10 = (0.5-dist1.fwd(-1))/(1-dist1.fwd(-1))
+    assert numpy.allclose(joint.fwd([[-1, 0, 1], [0, 0, 0]]),
+                          [dist1.fwd([-1, 0, 1]), [ref10, 0, 0]])
+
+
+def test_truncation_upper_as_dist():
+    """Ensure upper bound as a distribution is supported."""
+    dist1 = chaospy.Normal()
+    dist2 = chaospy.Trunc(chaospy.Normal(), upper=dist1)
+    joint = chaospy.J(dist1, dist2)
+    ref12 = 0.5/dist1.fwd(1)
+    assert numpy.allclose(joint.fwd([[-1, 0, 1], [0, 0, 0]]),
+                          [dist1.fwd([-1, 0, 1]), [1, 1, ref12]])
+
+
+def test_truncation_both_as_dist():
+    """Ensure that lower and upper bound combo is supported."""
+    dist1 = chaospy.Normal()
+    dist2 = chaospy.Normal()
+    dist3 = chaospy.Trunc(chaospy.Normal(), lower=dist1, upper=dist2)
+    joint = chaospy.J(dist1, dist2, dist3)
+    ref21 = (0.5-dist1.fwd(-1))/(1-dist1.fwd(-1))/dist2.fwd(1)
+    assert numpy.allclose(joint.fwd([[-1, -1,  1,  1],
+                                     [-1,  1, -1,  1],
+                                     [ 0,  0,  0,  0]]),
+                          [dist1.fwd([-1, -1,  1,  1]),
+                           dist2.fwd([-1,  1, -1,  1]),
+                           [1, ref21, 1, 0]])
+
+
+def test_trucation_multivariate():
+    """Ensure that multivariate bounds works as expected."""
+    dist1 = chaospy.Iid(chaospy.Normal(), 2)
+    dist2 = chaospy.Trunc(chaospy.Iid(chaospy.Normal(), 2),
+                          lower=dist1, upper=[1, 1])
+    joint = chaospy.J(dist1, dist2)
+    assert numpy.allclose(
+        joint.fwd([[-1, -1, -1, -1],
+                   [-1, -1, -1, -1],
+                   [ 0,  0, -2,  2],
+                   [-2,  2,  0,  0]]),
+        [[0.15865525, 0.15865525, 0.15865525, 0.15865525],
+         [0.15865525, 0.15865525, 0.15865525, 0.15865525],
+         [0.48222003, 0.48222003, 0.        , 1.        ],
+         [0.        , 1.        , 0.48222003, 0.48222003]],
+    )
+


### PR DESCRIPTION
Simplify the call signature for the user, allowing for both one-sided or two-sided truncation at the same time.

This means that instead of `cp.Trunc(-1, dist)`, one must now do `cp.Trunc(dist, lower=-1)`.
And instead of `cp.Trunc(-1, cp.Trunc(dist, 1))` one can do `cp.Trunc(dist, lower=-1, upper=1)`.