### PR TITLE
assert lower <= midpoint <= upper in Triangle distrubution

### DIFF
--- a/chaospy/distributions/collection/triangle.py
+++ b/chaospy/distributions/collection/triangle.py
@@ -5,6 +5,20 @@ from scipy import special, misc
 from ..baseclass import SimpleDistribution, LowerUpperDistribution
 from .beta import beta_
 
+def _get_triang_param_lb_and_ub(name, value):
+    try:
+        lb = ub = float(value)
+    except:
+        if hasattr(value, 'lower') and hasattr(value, 'upper'):
+            lb = value.lower.min()
+            ub = value.upper.max()
+        else:
+            raise ValueError(
+                f"{name} must be either a number or a distribution "
+                f"with lower and upper bounds; not a '{type(value).__name__}' "
+                 "object"
+            )
+    return lb, ub
 
 class triangle(SimpleDistribution):
     """Triangle probability distribution."""
@@ -75,9 +89,13 @@ class Triangle(LowerUpperDistribution):
 
     def __init__(self, lower=-1, midpoint=0, upper=1):
         repr_args = [lower, midpoint, upper]
-        assert lower <= midpoint <= upper, (
-            "Condition not satisfied: `lower <= midpoint <= upper`"
-        )
+        _, lower_ub = _get_triang_param_lb_and_ub('lower', lower)
+        mid_lb, mid_ub = _get_triang_param_lb_and_ub('midpoint', midpoint)
+        upper_lb, _ = _get_triang_param_lb_and_ub('upper', upper)
+        if not (lower_ub <= mid_lb  and mid_ub <= upper_lb):
+            raise ValueError(
+                "condition not satisfied: `lower <= midpoint <= upper`"
+            )
         midpoint = (midpoint-lower)*1./(upper-lower)
         super(Triangle, self).__init__(
             dist=triangle(midpoint),

--- a/chaospy/distributions/collection/triangle.py
+++ b/chaospy/distributions/collection/triangle.py
@@ -14,9 +14,9 @@ def _get_triang_param_lb_and_ub(name, value):
             ub = value.upper.max()
         else:
             raise ValueError(
-                f"{name} must be either a number or a distribution "
-                f"with lower and upper bounds; not a '{type(value).__name__}' "
-                 "object"
+                "%s must be either a number or a distribution " % name
+              + "with lower and upper bounds; not a '%s' " % type(value).__name__
+              + "object"
             )
     return lb, ub
 

--- a/chaospy/distributions/collection/triangle.py
+++ b/chaospy/distributions/collection/triangle.py
@@ -83,7 +83,7 @@ class Triangle(LowerUpperDistribution):
         0.0
         >>> distribution = chaospy.Triangle(-1, 2 ,1)
         Traceback (most recent call last):
-        AssertionError: Condition not satisfied: `lower <= midpoint <= upper`
+        ValueError: condition not satisfied: `lower <= midpoint <= upper`
 
     """
 

--- a/chaospy/distributions/collection/triangle.py
+++ b/chaospy/distributions/collection/triangle.py
@@ -67,11 +67,17 @@ class Triangle(LowerUpperDistribution):
         array([ 0.168, -0.52 ,  0.685, -0.018])
         >>> distribution.mom(1).round(4)
         0.0
+        >>> distribution = chaospy.Triangle(-1, 2 ,1)
+        Traceback (most recent call last):
+        AssertionError: Condition not satisfied: `lower <= midpoint <= upper`
 
     """
 
     def __init__(self, lower=-1, midpoint=0, upper=1):
         repr_args = [lower, midpoint, upper]
+        assert lower <= midpoint <= upper, (
+            "Condition not satisfied: `lower <= midpoint <= upper`"
+        )
         midpoint = (midpoint-lower)*1./(upper-lower)
         super(Triangle, self).__init__(
             dist=triangle(midpoint),

--- a/tests/distributions/collection/test_triangle.py
+++ b/tests/distributions/collection/test_triangle.py
@@ -1,0 +1,19 @@
+"""Test for Triangle distribution."""
+import pytest
+import chaospy as cp
+
+def test_triangle_init():
+    """Assert that initialization checks lower and upper bounds."""
+    # Should just run
+    u = cp.Uniform(0, 1)
+    t = cp.Triangle(u - 1, u, u + 1)
+    cp.J(u, t)
+    
+    # Overlapping lb and ub
+    with pytest.raises(ValueError): 
+        cp.Triangle(u - 0.5, u, u + 1)
+    with pytest.raises(ValueError): 
+        cp.Triangle(u - 1, u, u + 0.5)
+    
+    # Should initialize fine
+    cp.Triangle(u - 1, 0., u + 0.5)

--- a/tests/distributions/collection/test_triangle.py
+++ b/tests/distributions/collection/test_triangle.py
@@ -5,15 +5,15 @@ import chaospy as cp
 def test_triangle_init():
     """Assert that initialization checks lower and upper bounds."""
     # Should just run
-    u = cp.Uniform(0, 1)
-    t = cp.Triangle(u - 1, u, u + 1)
+    u = cp.Uniform(0., 1.)
+    t = cp.Triangle(u - 1., u, u + 1.)
     cp.J(u, t)
     
     # Overlapping lb and ub
     with pytest.raises(ValueError): 
-        cp.Triangle(u - 0.5, u, u + 1)
+        cp.Triangle(u - 0.5, u, u + 1.)
     with pytest.raises(ValueError): 
-        cp.Triangle(u - 1, u, u + 0.5)
+        cp.Triangle(u - 1., u, u + 0.5)
     
     # Should initialize fine
-    cp.Triangle(u - 1, 0., u + 0.5)
+    cp.Triangle(u - 1., 0., u + 0.5)


### PR DESCRIPTION
Hi!

Previously, the mode of a triangle distribution could be outside lower and upper bounds, leading to odd results like:

```python
>>> import chaospy
>>> distribution = chaospy.Triangle(-1, 2, 1)
>>> distribution.pdf(0.2)
array(0.4)
```

This pull request asserts that the condition is withheld:

```python
>>> import chaospy
>>> distribution = chaospy.Triangle(-1, 2 ,1)
Traceback (most recent call last):
AssertionError: Condition not satisfied: `lower <= midpoint <= upper`
```

A doctest is also added to show this (see commit).

Thanks,
Hope this helps!