### PR TITLE
Bugfix: implicit growth rule incorrectly set

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Master Branch
 =============
 
+Version 4.2.5 (2021-04-16)
+==========================
+
+FIXED:
+  * Bugfix: `sparse=True growth=None` should se `growth=True`, but didn't this
+    means that rules that require growth rules to be nested, i.e.
+    `clenshaw_curtis, fejer, discrete, newton_cotes` were not benefiting
+    fully from sparse-grid.
+
 Version 4.2.4 (2021-02-23)
 ==========================
 

--- a/chaospy/quadrature/sparse_grid.py
+++ b/chaospy/quadrature/sparse_grid.py
@@ -71,6 +71,7 @@ def construct_sparse_grid(
         array([ 0.17,  0.25, -0.5 ,  0.25,  0.67,  0.25, -0.5 ,  0.25,  0.17])
     """
     orders = order*numpy.ones(len(dist), dtype=int)
+    growth = True if growth is None else growth
 
     assert isinstance(dist, chaospy.Distribution), "dist must be chaospy.Distribution"
     dist = dist if isinstance(dist, (chaospy.J, chaospy.Iid)) else chaospy.J(dist)

--- a/docs/user_guide/quadrature.rst
+++ b/docs/user_guide/quadrature.rst
@@ -87,13 +87,15 @@ to the :func:`chaospy.generate_quadrature` function. For example::
     >>> distribution = chaospy.J(
     ...     chaospy.Uniform(0, 4), chaospy.Uniform(0, 4))
     >>> abscissas, weights = chaospy.generate_quadrature(
-    ...     3, distribution, sparse=True)
+    ...     2, distribution, sparse=True)
     >>> abscissas.round(4)
-    array([[0., 0., 0., 1., 2., 2., 2., 2., 2., 3., 4., 4., 4.],
-           [0., 2., 4., 2., 0., 1., 2., 3., 4., 2., 0., 2., 4.]])
+    array([[0.    , 0.    , 0.    , 0.5858, 2.    , 2.    , 2.    , 2.    ,
+            2.    , 3.4142, 4.    , 4.    , 4.    ],
+           [0.    , 2.    , 4.    , 2.    , 0.    , 0.5858, 2.    , 3.4142,
+            4.    , 2.    , 0.    , 2.    , 4.    ]])
     >>> weights.round(4)
-    array([-0.0833,  0.2222, -0.0833,  0.4444,  0.2222,  0.4444, -1.3333,
-            0.4444,  0.2222,  0.4444, -0.0833,  0.2222, -0.0833])
+    array([ 0.0278, -0.0222,  0.0278,  0.2667, -0.0222,  0.2667, -0.0889,
+            0.2667, -0.0222,  0.2667,  0.0278, -0.0222,  0.0278])
 
 This compared to the full tensor-product grid::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "chaospy"
-version = "4.2.4"
+version = "4.2.5"
 description = "Numerical tool for perfroming uncertainty quantification"
 license = "MIT"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
`sparse=True growth=None` should se `growth=True`, but didn't this means that rules that require growth rules to be nested, i.e. `clenshaw_curtis, fejer, discrete, newton_cotes` were not benefiting fully from sparse-grid.
those who set `growth` explicitly are not affected.