### PR TITLE
Change TrunkNormal distribution type.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Master Branch
 =============
 
+Version 4.2.6 (2021-05-10)
+==========================
+
+FIXED:
+  * `TruncNormal` is a `ShiftScaleDistribution`, not a `J` operator.
+
 Version 4.2.5 (2021-04-16)
 ==========================
 

--- a/chaospy/distributions/collection/trunc_normal.py
+++ b/chaospy/distributions/collection/trunc_normal.py
@@ -4,9 +4,7 @@ from scipy import special
 import chaospy
 
 from .normal import normal
-from ..baseclass import SimpleDistribution
-from ..operators import J
-
+from ..baseclass import SimpleDistribution, ShiftScaleDistribution
 
 
 class trunc_normal(SimpleDistribution):
@@ -47,7 +45,7 @@ class trunc_normal(SimpleDistribution):
         return numpy.where(b > upper, upper, b)
 
 
-class TruncNormal(J):
+class TruncNormal(ShiftScaleDistribution):
     """
     Truncated normal distribution
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "chaospy"
-version = "4.2.5"
+version = "4.2.6"
 description = "Numerical tool for perfroming uncertainty quantification"
 license = "MIT"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
TrunkNormal has mistakenly been classified as a J operator.
It has now correctly been changed to a ShiftScaleDistribution.