### PR TITLE
Remove direct key access in ndpoly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Master Branch
 =============
 
+Version 4.3.2 (2021-05-26)
+==========================
+
+FIXED:
+  * Compatibility with `numpoly`: Update string key access to `ndpoly` objects.
+
 Version 4.3.1 (2021-03-18)
 ==========================
 

--- a/chaospy/descriptives/conditional.py
+++ b/chaospy/descriptives/conditional.py
@@ -73,5 +73,5 @@ def E_cond(poly, freeze, dist, **kws):
 
     # Remove frozen coefficients, such that poly == sum(frozen*unfrozen) holds
     for key in unfrozen.keys:
-        unfrozen[key] = unfrozen[key] != 0
+        unfrozen.values[key] = unfrozen.values[key] != 0
     return numpoly.sum(frozen*expected.E(unfrozen, dist), 0)

--- a/chaospy/descriptives/expected.py
+++ b/chaospy/descriptives/expected.py
@@ -45,5 +45,5 @@ def E(poly, dist=None, **kws):
 
     out = numpy.zeros(poly.shape)
     for idx, key in enumerate(poly.keys):
-        out += poly[key]*moments[idx]
+        out += poly.values[key]*moments[idx]
     return out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.masonry.api"
 
 [tool.poetry]
 name = "chaospy"
-version = "4.3.1"
+version = "4.3.2"
 description = "Numerical tool for perfroming uncertainty quantification"
 license = "MIT"
 authors = ["Jonathan Feinberg"]


### PR DESCRIPTION
numpoly deprecated direct string key access to polynomial coefficient memory a while back.
Correct usage should now be `poly.values[key]`.
numpoly 1.2.X series made the old access pattern illegal.

Solves #343.