### PR TITLE
Fix typo in metadata (setup.cfg)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 version = 0.1.0
 name = chaospy
-description = "Numerical tool for perfroming uncertainty quantification"
+description = "Numerical tool for performing uncertainty quantification"
 long_description = file: README.rst, CHANGELOG.rst LICENSE.txt
 long_description_content_type = text/x-rst
 license = MIT


### PR DESCRIPTION
Only minor typo fix in metadata. 