### PR TITLE
Remove overwritten loglevel

### DIFF
--- a/chaospy/__init__.py
+++ b/chaospy/__init__.py
@@ -43,7 +43,6 @@ def configure_logging():
     loglevel = (
         logging.DEBUG if os.environ.get("CHAOSPY_DEBUG", "") == "1" else logging.WARNING
     )
-    loglevel = logging.DEBUG
     streamer.setLevel(loglevel)
 
     logger = logging.getLogger("chaospy")


### PR DESCRIPTION
loglevel is overwritten to always be debug, regardless of the CHAOSPY_DEBUG flag. This causes a bunch of annoying messages to be written to the screen unless the user explicitly gets both chaospy and numpoly logs and overrides the log level.