### PR TITLE
Improved OpenTURNS distributions wrapper

### DIFF
--- a/chaospy/external/openturns_.py
+++ b/chaospy/external/openturns_.py
@@ -138,23 +138,20 @@ class OpenTURNSDist(J):
     """
 
     def __init__(self, distribution):
-        from openturns import ComposedDistribution, ContinuousDistribution
-
-        if isinstance(distribution, ComposedDistribution):
+        if isinstance(distribution, Iterable):
+            assert all([dist.isContinuous() for dist in distribution]
+            ), "Only (iterable of) continuous OpenTURNS distributions supported"
+            distributions = [openturns_dist(dist) for dist in distribution]
+        else:
+            from openturns import Distribution, DistributionImplementation
+            if isinstance(distribution, Distribution) or isinstance(distribution, DistributionImplementation):
+                assert distribution.isContinuous(), "Only (iterable of) continuous OpenTURNS distributions supported"
             if not distribution.hasIndependentCopula():
                 raise chaospy.StochasticallyDependentError(
                     "Stochastically dependent " "OpenTURNS distribution unsupported"
                 )
             distributions = [
                 openturns_dist(dist)
-                for dist in distribution.getDistributionCollection()
-            ]
-        elif isinstance(distribution, ContinuousDistribution):
-            distributions = [openturns_dist(distribution)]
-        else:
-            assert isinstance(distribution, Iterable) and all(
-                [isinstance(dist, ContinuousDistribution) for dist in distribution]
-            ), "Only (iterable of) continuous OpenTURNS distributions supported"
-            distributions = [openturns_dist(dist) for dist in distribution]
+                for dist in [distribution.getMarginal(i) for i in range(distribution.getDimension())]]
         super(OpenTURNSDist, self).__init__(*distributions)
         self._repr_args = [distributions]


### PR DESCRIPTION
Now it is possible to use a continuous distribution *dist* by checking its property *dist.isContinuous()* instead of its type *isInstance(dist, ContinuousDistribution)*

It allows to use more advanced OpenTURNS distributions such as Mixture, BayesDistribution, ConditionalDistribution in an attempt to fix #403.