### PR TITLE
Add missing importlib-metadata dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   "numpoly >=1.2.5",
   "scipy",
   "setuptools >=40.9.0",
+  "importlib-metadata"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ numpoly
 numpy
 scipy
 matplotlib
+importlib-metadata


### PR DESCRIPTION
An alternative to this PR would be to increase the minimum python version to 3.8 and use importlib.metadata from the standard library. Although importlib_metadata is essentially a copy of that