### PR TITLE
Replace `np.asfarray`

### DIFF
--- a/chaospy/descriptives/sensitivity/main.py
+++ b/chaospy/descriptives/sensitivity/main.py
@@ -75,7 +75,7 @@ def FirstOrderSobol(
     for idx in range(len(expansion)):
         expons = numpy.array([key for key, value in dic.items() if value[idx]])
         alphas.append(tuple(expons[numpy.argmax(expons.sum(1))]))
-    coefficients = numpy.asfarray(coefficients)
+    coefficients = numpy.asarray(coefficients)
 
     index = numpy.array([any(alpha) for alpha in alphas])
     variance = numpy.sum(coefficients[index] ** 2, axis=0)

--- a/chaospy/descriptives/sensitivity/main2.py
+++ b/chaospy/descriptives/sensitivity/main2.py
@@ -97,7 +97,7 @@ def SecondOrderSobol(
     for idx in range(len(expansion)):
         expons = numpy.array([key for key, value in dic.items() if value[idx]])
         alphas.append(tuple(expons[numpy.argmax(expons.sum(1))]))
-    coefficients = numpy.asfarray(coefficients)
+    coefficients = numpy.asarray(coefficients)
 
     index = numpy.array([any(alpha) for alpha in alphas])
     variance = numpy.sum(coefficients[index] ** 2, axis=0)

--- a/chaospy/descriptives/sensitivity/total.py
+++ b/chaospy/descriptives/sensitivity/total.py
@@ -80,7 +80,7 @@ def TotalOrderSobol(
     for idx in range(len(expansion)):
         expons = numpy.array([key for key, value in dic.items() if value[idx]])
         alphas.append(tuple(expons[numpy.argmax(expons.sum(1))]))
-    coefficients = numpy.asfarray(coefficients)
+    coefficients = numpy.asarray(coefficients)
 
     index = numpy.array([any(alpha) for alpha in alphas])
     variance = numpy.sum(coefficients[index] ** 2, axis=0)

--- a/chaospy/distributions/approximation.py
+++ b/chaospy/distributions/approximation.py
@@ -256,7 +256,7 @@ def approximate_density(distribution, idx, xloc, cache=None, step_size=1e-7):
     """
     cache = {} if cache is None else cache
     assert (idx, distribution) not in cache
-    xloc = numpy.asfarray(xloc)
+    xloc = numpy.asarray(xloc)
     assert xloc.ndim == 1
     lower, upper = numpy.min(xloc), numpy.max(xloc)
     middle = 0.5 * (lower + upper)

--- a/chaospy/distributions/baseclass/distribution.py
+++ b/chaospy/distributions/baseclass/distribution.py
@@ -194,7 +194,7 @@ class Distribution(object):
         """
         logger = logging.getLogger(__name__)
         check_dependencies(self)
-        x_data = numpy.asfarray(x_data)
+        x_data = numpy.asarray(x_data)
         shape = x_data.shape
         x_data = x_data.reshape(len(self), -1)
         cache = {}
@@ -312,7 +312,7 @@ class Distribution(object):
         """
         logger = logging.getLogger(__name__)
         check_dependencies(self)
-        q_data = numpy.asfarray(q_data)
+        q_data = numpy.asarray(q_data)
         assert numpy.all((q_data >= 0) & (q_data <= 1)), "sanitize your inputs!"
         shape = q_data.shape
         q_data = q_data.reshape(len(self), -1)
@@ -468,7 +468,7 @@ class Distribution(object):
         """
         logger = logging.getLogger(__name__)
         check_dependencies(self)
-        x_data = numpy.asfarray(x_data)
+        x_data = numpy.asarray(x_data)
         shape = x_data.shape
         x_data = x_data.reshape(len(self), -1)
         f_data = numpy.zeros(x_data.shape)
@@ -732,8 +732,8 @@ class Distribution(object):
         alpha, beta = self._ttr(kdata, **parameters)
         assert not isinstance(alpha, Distribution), (self, alpha)
         assert not isinstance(beta, Distribution), (self, beta)
-        alpha = numpy.asfarray(alpha).item()
-        beta = numpy.asfarray(beta).item()
+        alpha = numpy.asarray(alpha).item()
+        beta = numpy.asarray(beta).item()
         self._ttr_cache[idx, kdata] = (alpha, beta)
         return alpha, beta
 

--- a/chaospy/distributions/copulas/t_copula.py
+++ b/chaospy/distributions/copulas/t_copula.py
@@ -118,7 +118,7 @@ class TCopula(CopulaDistribution):
         """
         assert len(dist) == len(covariance)
         df = float(df)
-        covariance = numpy.asfarray(covariance)
+        covariance = numpy.asarray(covariance)
         super(TCopula, self).__init__(
             dist=dist,
             trans=t_copula(df, covariance, dist._rotation),

--- a/chaospy/distributions/kernel/baseclass.py
+++ b/chaospy/distributions/kernel/baseclass.py
@@ -60,7 +60,7 @@ class KernelDensityBaseclass(Distribution):
                 raise ValueError("unknown estimator rule: %s" % estimator_rule)
 
         else:
-            covariance = numpy.asfarray(h_mat)
+            covariance = numpy.asarray(h_mat)
             if covariance.ndim in (0, 1):
                 covariance = covariance * numpy.eye(len(samples))
         if covariance.ndim == 2:

--- a/chaospy/distributions/kernel/mixture.py
+++ b/chaospy/distributions/kernel/mixture.py
@@ -68,7 +68,7 @@ class GaussianMixture(GaussianKDE):
         means = numpy.atleast_2d(numpy.transpose(means))
         n, m = means.shape
 
-        covariances = numpy.asfarray(covariances)
+        covariances = numpy.asarray(covariances)
         if covariances.ndim in (1, 2):
             covariances = numpy.broadcast_to(covariances.T, (n, n, m))
         else:

--- a/chaospy/distributions/operators/addition.py
+++ b/chaospy/distributions/operators/addition.py
@@ -123,7 +123,7 @@ class Add(OperatorDistribution):
     def _cdf(self, xloc, idx, left, right, cache):
         if isinstance(right, Distribution):
             left, right = right, left
-        xloc = (xloc.T - numpy.asfarray(right).T).T
+        xloc = (xloc.T - numpy.asarray(right).T).T
         uloc = left._get_fwd(xloc, idx, cache=cache)
         return uloc
 
@@ -142,7 +142,7 @@ class Add(OperatorDistribution):
         """
         if isinstance(right, Distribution):
             left, right = right, left
-        xloc = (xloc.T - numpy.asfarray(right).T).T
+        xloc = (xloc.T - numpy.asarray(right).T).T
         return left._get_pdf(xloc, idx, cache=cache)
 
     def _ppf(self, uloc, idx, left, right, cache):
@@ -161,7 +161,7 @@ class Add(OperatorDistribution):
         if isinstance(right, Distribution):
             left, right = right, left
         xloc = left._get_inv(uloc, idx, cache=cache)
-        right = numpy.asfarray(right)
+        right = numpy.asarray(right)
         return self._operator(xloc, right)
 
     def _mom(self, keys, left, right, cache):

--- a/chaospy/distributions/operators/multiply.py
+++ b/chaospy/distributions/operators/multiply.py
@@ -233,7 +233,7 @@ class Multiply(OperatorDistribution):
         """
         if isinstance(right, Distribution):
             left, right = right, left
-        uloc = numpy.where(numpy.asfarray(right).T > 0, uloc.T, 1 - uloc.T).T
+        uloc = numpy.where(numpy.asarray(right).T > 0, uloc.T, 1 - uloc.T).T
         xloc = left._get_inv(uloc, idx, cache=cache)
         xloc = (xloc.T * right.T).T
 
@@ -260,7 +260,7 @@ class Multiply(OperatorDistribution):
         """
         if isinstance(right, Distribution):
             left, right = right, left
-        right = (numpy.asfarray(right).T + numpy.zeros(xloc.shape).T).T
+        right = (numpy.asarray(right).T + numpy.zeros(xloc.shape).T).T
         valids = right != 0
         xloc = xloc.copy()
         xloc.T[valids.T] = xloc.T[valids.T] / right.T[valids.T]

--- a/chaospy/distributions/sampler/antithetic.py
+++ b/chaospy/distributions/sampler/antithetic.py
@@ -19,7 +19,7 @@ def create_antithetic_variates(samples, axes=()):
         Same as ``samples``, but with samples internally reflected. roughly
         equivalent to ``numpy.vstack([samples, 1-samples])`` in one dimensions.
     """
-    samples = numpy.asfarray(samples)
+    samples = numpy.asarray(samples)
     assert numpy.all(samples <= 1) and numpy.all(
         samples >= 0
     ), "all samples assumed on interval [0, 1]."

--- a/chaospy/distributions/sampler/generator.py
+++ b/chaospy/distributions/sampler/generator.py
@@ -67,7 +67,7 @@ def generate_samples(order, domain=1, rule="random", antithetic=None):
         trans = lambda x_data: x_data
 
     elif isinstance(domain, (tuple, list, numpy.ndarray)):
-        domain = numpy.asfarray(domain)
+        domain = numpy.asarray(domain)
         if len(domain.shape) < 2:
             dim = 1
         else:

--- a/chaospy/expansion/cholesky.py
+++ b/chaospy/expansion/cholesky.py
@@ -138,7 +138,7 @@ def gill_king(mat, tolerance=1e-16):
                [2.   , 6.   , 3.   ],
                [1.   , 3.   , 3.004]])
     """
-    mat = numpy.asfarray(mat)
+    mat = numpy.asarray(mat)
     assert numpy.allclose(mat, mat.T)
 
     size = mat.shape[0]

--- a/chaospy/expansion/lagrange.py
+++ b/chaospy/expansion/lagrange.py
@@ -42,7 +42,7 @@ def lagrange(abscissas, graded=True, reverse=True, sort=None):
             ...
         LinAlgError: Lagrange abscissas resulted in invertible matrix
     """
-    abscissas = numpy.asfarray(abscissas)
+    abscissas = numpy.asarray(abscissas)
     if len(abscissas.shape) == 1:
         abscissas = abscissas.reshape(1, abscissas.size)
     dim, size = abscissas.shape

--- a/chaospy/quadrature/kronrod.py
+++ b/chaospy/quadrature/kronrod.py
@@ -249,4 +249,4 @@ def kronrod_jacobi(order, coeffs):
     coeffs_a[2 * order] = (
         coeffs_a[order - 1] - coeffs_b[2 * order] * sigma[0, 1] / sigma[1, 1]
     )
-    return numpy.asfarray([coeffs_a, coeffs_b])
+    return numpy.asarray([coeffs_a, coeffs_b])

--- a/chaospy/quadrature/leja.py
+++ b/chaospy/quadrature/leja.py
@@ -111,11 +111,11 @@ def leja(
         index = numpy.argmin(vals)
         abscissas.insert(index + 1, opts[index])
 
-    abscissas = numpy.asfarray(abscissas).flatten()[1:-1]
+    abscissas = numpy.asarray(abscissas).flatten()[1:-1]
     weights = create_weights(abscissas, dist, rule)
     abscissas = abscissas.reshape(1, abscissas.size)
 
-    return numpy.asfarray(abscissas), numpy.asfarray(weights).flatten()
+    return numpy.asarray(abscissas), numpy.asarray(weights).flatten()
 
 
 def create_weights(

--- a/chaospy/recurrence/chebyshev.py
+++ b/chaospy/recurrence/chebyshev.py
@@ -24,7 +24,7 @@ def modified_chebyshev(moments):
         array([[0.        , 0.        , 0.        , 0.        ],
                [1.        , 0.33333333, 0.26666667, 0.25714286]])
     """
-    moments = numpy.asfarray(moments).flatten()
+    moments = numpy.asarray(moments).flatten()
     order = len(moments)
     assert order % 2 == 0
 

--- a/chaospy/recurrence/jacobi.py
+++ b/chaospy/recurrence/jacobi.py
@@ -20,7 +20,7 @@ def coefficients_to_quadrature(coeffs):
         >>> weights.round(4)
         array([0.0113, 0.2221, 0.5333, 0.2221, 0.0113])
     """
-    coeffs = numpy.asfarray(coeffs)
+    coeffs = numpy.asarray(coeffs)
     if len(coeffs.shape) == 2:
         coeffs = coeffs.reshape(1, 2, -1)
     assert len(coeffs.shape) == 3, "shape %s not allowed" % coeffs.shape

--- a/chaospy/recurrence/lanczos.py
+++ b/chaospy/recurrence/lanczos.py
@@ -118,4 +118,4 @@ def lanczos(
                 alpha[idy] -= increment_new - increment
                 beta[idy] = beta_new
 
-    return numpy.asfarray([alpha.ravel(), beta.ravel()])
+    return numpy.asarray([alpha.ravel(), beta.ravel()])

--- a/chaospy/recurrence/stieltjes.py
+++ b/chaospy/recurrence/stieltjes.py
@@ -118,7 +118,7 @@ def discretized_stieltjes(
         variables = list(numpoly.variable(len(dist)))
         orths = [orths[idx](q0=variables[idx]) for idx in range(len(dist))]
         orths = numpoly.polynomial(orths).reshape(len(dist), order + 1)
-        norms = numpy.asfarray(norms).reshape(len(dist), order + 1)
+        norms = numpy.asarray(norms).reshape(len(dist), order + 1)
         return coeffs, orths, norms
 
     if rule is None:

--- a/chaospy/spectral.py
+++ b/chaospy/spectral.py
@@ -43,9 +43,9 @@ def fit_quadrature(orth, nodes, weights, solves, retall=False, norms=None):
     """
     orth = numpoly.polynomial(orth)
     assert orth.ndim == 1
-    weights = numpy.asfarray(weights)
+    weights = numpy.asarray(weights)
     assert weights.ndim == 1
-    solves = numpy.asfarray(solves)
+    solves = numpy.asarray(solves)
     nodes = numpy.atleast_2d(nodes)
     assert nodes.ndim == 2
     assert nodes.shape[1] == len(weights) == len(solves)
@@ -58,7 +58,7 @@ def fit_quadrature(orth, nodes, weights, solves, retall=False, norms=None):
 
     if norms is None:
         norms = numpy.sum(ovals**2 * weights, -1)
-    norms = numpy.asfarray(norms)
+    norms = numpy.asarray(norms)
     assert norms.ndim == 1
 
     coeffs = (numpy.sum(vals1, 1).T / norms).T


### PR DESCRIPTION
numpy's `asfarray` is also depreciated since 2.0 in favor of `asarray`. I just replaced all occurences and now it seems as if the package is numpy 2.0 compatible.